### PR TITLE
Docs: fill in README and add task.md spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,116 @@
-# posttrain
+# PostTrain Arena
+
+**The open arena for post-training.**
+
+Contribute an RL environment. We post-train a model on it and score what
+generalizes across eight under-served domains.
+
+[Website](https://posttrain.com) · [Full spec](https://posttrain.com/docs/spec) · [Browse the catalog](https://posttrain.com/catalog) · [Discord](https://discord.gg/mZ9Rc8q8W3)
+
+---
+
+## What this is
+
+PostTrain Arena is an open competition. Anyone can contribute a self-contained
+reinforcement-learning environment: a task an agent attempts, a sandbox it runs
+in, and a verifier that scores the result. Accepted tasks are released openly.
+We then post-train a model across the accepted pool and measure what generalizes
+to a private held-out suite — so contributions are rewarded for teaching
+transferable skills, not for overfitting a single benchmark.
+
+## How it works
+
+1. **Contribute.** Open a pull request with a task package (see below).
+2. **Post-train.** We post-train a Qwen3-8B model across the accepted task pool.
+3. **Score.** We evaluate the trained model on IndexBench, a private held-out
+   suite where no single domain exceeds 20% of the tasks.
+4. **Rank.** Standings are published once Phase 1 begins.
+
+## The eight under-served domains
+
+Every task declares one `category`. We are deliberately seeking coverage in
+domains the open ecosystem under-serves:
+
+| Domain | `category` |
+| --- | --- |
+| Sciences | `sciences` |
+| Industrial & Energy Operations | `industrial-energy` |
+| Cybersecurity | `cybersecurity` |
+| Finance & Economics | `finance` |
+| Office & Knowledge Work | `office-knowledge-work` |
+| Media & Multimodal Content | `media` |
+| AI/ML & Agentic Systems | `aiml` |
+| Software Engineering | `swe` |
+
+## Contribute a task
+
+A submission is four pieces in one directory:
+
+```
+tasks/
+└─ your-task-name/
+   ├─ task.md          # frontmatter (limits, metadata) + the prompt
+   ├─ environment/     # Dockerfile + any seed data the agent reads
+   ├─ verifier/        # scoring logic + a plain-language rubric
+   └─ oracle/          # a reference solution that proves the task is solvable
+```
+
+- **`task.md`** — a single human-authored file: YAML frontmatter for limits and
+  metadata, a Markdown body for the prompt (and optional multi-agent scenes,
+  roles, and a simulated user).
+- **`environment/`** — a sealed `Dockerfile` built fresh per task, plus any seed
+  files. Start from a plain base and add only what the task needs.
+- **`verifier/`** — runs after the agent finishes and emits a reward in `[0,1]`,
+  plus a rubric reviewers read for edge cases.
+- **`oracle/`** — a reference solution that achieves a passing reward, so
+  reviewers (and CI) can confirm the task is solvable.
+
+The fastest way to start is to copy the template:
+
+```bash
+cp -R tasks/template tasks/your-task-name
+```
+
+The full authoring reference — frontmatter schema, body sections, verifier and
+oracle contracts — is in **[SPEC.md](SPEC.md)** (and rendered at
+[posttrain.com/docs/spec](https://posttrain.com/docs/spec)).
+
+## Validate locally
+
+Use the `bench` CLI to validate before opening a PR:
+
+```bash
+# Schema-only — fast, no Docker required
+bench tasks check ./tasks/your-task-name --level schema
+
+# Publication-grade — builds the image, runs the oracle, scores it
+bench tasks check ./tasks/your-task-name --level publication-grade
+```
+
+Install it once:
+
+```bash
+uv tool install benchflow   # recommended (isolated, fast)
+# or
+pip install benchflow
+```
+
+## Submit
+
+Open a pull request against this repository with your task directory under
+`tasks/`. Include the local `publication-grade` output in the PR description so
+reviewers know it built and passed on your machine. Discussion happens on
+[Discord](https://discord.gg/mZ9Rc8q8W3) and in the PR thread.
+
+Accepted tasks are released openly.
+
+## Links
+
+- Website — https://posttrain.com
+- Task spec — https://posttrain.com/docs/spec
+- Environment catalog — https://posttrain.com/catalog
+- Discord — https://discord.gg/mZ9Rc8q8W3
+
+## License
+
+See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ tasks/
 - **`oracle/`** — a reference solution that achieves a passing reward, so
   reviewers (and CI) can confirm the task is solvable.
 
-The fastest way to start is to copy the template:
+The fastest way to start is to scaffold one:
 
 ```bash
-cp -R tasks/template tasks/your-task-name
+bench tasks init tasks/your-task-name
 ```
 
 The full authoring reference — frontmatter schema, body sections, verifier and

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Contribute an RL environment. We post-train a model on it and score what
 generalizes across eight under-served domains.
 
-[Website](https://posttrain.com) · [Full spec](https://posttrain.com/docs/spec) · [Browse the catalog](https://posttrain.com/catalog) · [Discord](https://discord.gg/mZ9Rc8q8W3)
+[Website](https://posttrain.com) · [Full spec](SPEC.md) · [Browse the catalog](https://posttrain.com/catalog) · [Discord](https://discord.gg/mZ9Rc8q8W3)
 
 ---
 
@@ -72,8 +72,7 @@ bench tasks init tasks/your-task-name
 ```
 
 The full authoring reference — frontmatter schema, body sections, verifier and
-oracle contracts — is in **[SPEC.md](SPEC.md)** (and rendered at
-[posttrain.com/docs/spec](https://posttrain.com/docs/spec)).
+oracle contracts — is in **[SPEC.md](SPEC.md)**.
 
 ## Validate locally
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Accepted tasks are released openly.
 ## Links
 
 - Website — https://posttrain.com
-- Task spec — https://posttrain.com/docs/spec
+- Task spec — [SPEC.md](SPEC.md)
 - Environment catalog — https://posttrain.com/catalog
 - Discord — https://discord.gg/mZ9Rc8q8W3
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -117,7 +117,7 @@ with `bench tasks normalize`:
 
 ```md
 ---
-preset: [code-change]
+profile: [code-change]   # authoring preset; expanded by `bench tasks normalize`
 name: my-namespace/my-task
 image: ubuntu:24.04
 verifier: verifier/

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,355 +1,288 @@
 # task.md specification
 
-How to author a PostTrain Arena submission. This is the reference; the body of
-each section is what reviewers compare against. The same content is rendered at
-[posttrain.com/docs/spec](https://posttrain.com/docs/spec).
+How to author a PostTrain Arena submission. A task packages an instruction, a
+sandboxed environment, and a verifier into a directory that we run and score
+automatically. Authoring writes one `task.md`.
 
-A submission is four pieces in one directory: a `task.md`, an `environment/`, a
-`verifier/`, and an `oracle/`.
+This is the reference; the body of each section is what reviewers compare
+against.
 
 ## Contents
 
-- [Overview](#overview)
-- [Submission layout](#submission-layout)
+- [Directory layout](#directory-layout)
 - [task.md](#taskmd)
 - [environment/](#environment)
 - [verifier/](#verifier)
 - [oracle/](#oracle)
-- [Validate locally](#validate-locally)
+- [CLI](#cli)
 - [Submit](#submit)
 
-## Overview
-
-PostTrain Arena tasks are *self-contained*: a fresh checkout plus Docker is
-enough to build the environment, run an agent, and score the result. There is no
-hidden runtime config; every limit and scoring rule lives in the submission
-directory.
-
-The format is built on `task.md` — a single human-authored file with YAML
-frontmatter (limits, metadata, optional multi-agent structure) and a Markdown
-body (the prompt, plus optional per-scene or per-role guidance). It expands
-through defaults into the same canonical contract that the eval pipeline
-consumes, so a minimal author file stays small but a richer one can spell out
-scenes, roles, and a simulated user without leaving the file.
-
-## Submission layout
+## Directory layout
 
 ```
-tasks/
-└─ your-task-name/
-   ├─ task.md                    # required — frontmatter + prompt
-   ├─ environment/
-   │  ├─ Dockerfile              # required — built fresh per task
-   │  ├─ <seed-data>             # optional — any files the agent reads
-   │  └─ skills/                 # optional — agent-discoverable skill packages
-   ├─ verifier/
-   │  ├─ test.sh                 # required — pytest runner shim (boilerplate)
-   │  ├─ test_outputs.py         # required — the actual checks
-   │  ├─ verifier.md             # required — rubric declaration (frontmatter)
-   │  └─ rubrics/
-   │     └─ verifier.md          # required — plain-language pass criteria
-   └─ oracle/
-      └─ solve.sh                # required — produces a passing trial
+my-task/
+├── task.md                # config + prompt + optional roles/scenes/user
+├── environment/
+│   └── Dockerfile         # sandbox image
+├── verifier/
+│   ├── verifier.md        # optional — selects the verifier strategy
+│   └── test.sh            # the script verifier (writes the reward)
+└── oracle/                # optional — reference solution proving solvability
+    └── solve.sh
 ```
 
-Naming convention: `<env-or-domain>-<short-description>` — for example
-`gmail-workflow-delegation` or `finance-weighted-gdp-calc`. Category, modality,
-and any safety qualifier live in the frontmatter, not the directory name.
+`verifier/` may also include `test_outputs.py` (a pytest module called by
+`test.sh`), rubric files, and judge prompts.
 
-The fastest way to start is `cp -R tasks/template tasks/your-task-name` from a
-fresh checkout. The three `skillsbench-*` tasks in the repo are the working
-references — copy the parts you need from them.
+Scaffold a new task with `bench tasks init my-task` (see [CLI](#cli)). It writes
+`task.md`, `environment/Dockerfile`, `verifier/test.sh`, `verifier/verifier.md`,
+`verifier/rubrics/`, and `oracle/solve.sh`, with `[REPLACE: ...]` markers so
+`bench tasks check` stays red until the package has real semantics.
 
 ## task.md
 
-Two halves separated by a `---` fence: YAML frontmatter on top, Markdown body
-below. Frontmatter declares limits and metadata; the body holds the prompt and,
-optionally, per-scene or per-role instructions and a user persona.
+A single file: YAML frontmatter (config) on top, a Markdown body (the prompt and
+optional role / scene / user-persona guidance) below.
 
-### Minimal example
-
-```yaml
+```md
 ---
-version: "1.0"
+schema_version: "1.3"
 metadata:
-  author_name: Ada Lovelace
-  author_email: ada@example.com
+  author_name: alice
   category: sciences
-  difficulty: medium
-  tags: [calculation, spreadsheet]
+  difficulty: easy
 agent:
-  timeout_sec: 900
+  timeout_sec: 300
 verifier:
-  timeout_sec: 180
+  timeout_sec: 120
 environment:
+  network_mode: no-network
   cpus: 1
-  memory_mb: 4096
+  memory_mb: 2048
+  storage_mb: 10240
+agents:
+  roles:
+    solver:
+      agent: codex
+scenes:
+  - name: solve
+    roles: [solver]
 ---
 
 ## prompt
 
-State the task here. One short paragraph that the agent will read first,
-followed by any structured detail it needs.
+Create the requested files in `/app`.
+
+## role:solver
+
+You are responsible for the implementation.
+
+## scene:solve
+
+Solve the task end to end.
 ```
 
-### Frontmatter reference
+### Frontmatter
 
-All fields are optional unless marked required. Limits default to safe values
-(verifier 180s, agent 900s, 1 CPU, 4 GB RAM). Field names use snake_case
-throughout.
+Unknown config keys fail validation; arbitrary labels belong under `metadata`.
 
-- `version` (required) — schema version, currently `"1.0"`.
-- `metadata.author_name` + `author_email` (required) — contact for the contributor.
-- `metadata.category` (required) — one of the eight domains, e.g. `sciences`, `cybersecurity`, `office-knowledge-work`.
+- `schema_version` (required) — currently `"1.3"`.
+- `metadata.author_name` — contact for the contributor.
+- `metadata.category` — one of the eight PostTrain Arena domains, e.g. `sciences`, `cybersecurity`, `office-knowledge-work`.
 - `metadata.difficulty` — `easy` | `medium` | `hard`.
 - `metadata.tags` — short string list, used for routing and filtering.
 - `agent.timeout_sec` — wall-clock budget for the agent.
 - `verifier.timeout_sec` — budget for the scoring run after the agent finishes.
+- `environment.network_mode` — `no-network` (default), `allowlist` (with `allowed_hosts`), or `public`.
 - `environment.cpus` / `memory_mb` / `storage_mb` — sandbox limits.
-- `environment.network_mode` — `no-network` (default), `allowlist` with `allowed_hosts`, or `public`.
-- `agents.roles` — optional named roles when the task is multi-agent (see below).
-- `scenes` — optional ordered list of scenes, each referencing one or more roles.
-- `user` — optional simulated-user model + stop rule when the agent needs a counterpart.
+- `environment.env` — host variables to inject, e.g. `OPENAI_API_KEY: ${OPENAI_API_KEY}`.
+- `agents.roles` — named roles when the task is multi-agent.
+- `scenes` — ordered list of scenes, each referencing one or more `roles`.
+- `user` — simulated-user model + stop rule when the agent needs a counterpart.
 
 ### Body sections
 
 The body is Markdown with a small set of well-known headings. Anything not
-matching a known heading is passed through as authoring notes and ignored by the
-runtime.
+matching a known heading is passed through as authoring notes.
 
-- `## prompt` (required) — what the agent sees first.
-- `## scene:<name>` — guidance shown when that scene starts, if you declared `scenes`.
+- `## prompt` (required) — what the agent sees first. State the goal in the first sentence; name exact files/paths; specify constraints. Don't mention the verifier or `reward.txt`.
 - `## role:<name>` — guidance shown to that role, if you declared `agents.roles`.
+- `## scene:<name>` — guidance shown when that scene starts, if you declared `scenes`.
 - `## user-persona` — the simulated user's mindset, if you declared `user`.
 
-### Multi-agent example
+### Minimal authoring presets
 
-The richer form composes roles, scenes, and a simulated user in one file — the
-same authoring document the eval pipeline consumes directly:
+You can start from a tiny document and expand it into the canonical contract
+with `bench tasks normalize`:
 
-```yaml
+```md
 ---
-version: "1.0"
-metadata:
-  author_name: benchflow
-  category: office-knowledge-work
-  difficulty: hard
-  tags: [multi-agent, planning]
-agent:
-  timeout_sec: 1200
-verifier:
-  timeout_sec: 240
-environment:
-  cpus: 2
-  memory_mb: 4096
-agents:
-  roles:
-    planner:
-      agent: claude-agent-acp
-      model: claude-sonnet-4-6
-    executor:
-      agent: codex-acp
-      model: gpt-5.5
-      reasoning_effort: high
-scenes:
-  - name: plan
-    turns: [{ role: planner }]
-  - name: implement
-    turns: [{ role: executor }]
-user:
-  model: claude-haiku
-  stop_rule: satisfied-or-5-rounds
+preset: [code-change]
+name: my-namespace/my-task
+image: ubuntu:24.04
+verifier: verifier/
+oracle: oracle/
 ---
 
-## prompt
-
-Refactor the tiny service so it keeps the same public behavior while splitting
-request parsing, business logic, and output formatting into separate modules.
-
-## scene:plan
-
-Read the task, inspect the code, and write a concise implementation plan.
-
-## scene:implement
-
-Apply the plan. Run the verifier before finishing.
-
-## user-persona
-
-You are impatient and only reveal the order id if the agent asks for it
-specifically.
+Implement the requested change in `/app`.
 ```
+
+Presets are authoring sugar that `bench tasks normalize` expands and then
+discards. Available presets include `code-change`, `reward-kit`,
+`acceptance-live`, `multi-agent`, and `leaderboard-local`. Run
+`bench tasks normalize my-task/ --write` to expand in place, or without
+`--write` to print the expanded `task.md`.
 
 ## environment/
 
-The environment directory holds the Dockerfile and any seed data the agent needs
-at trial time. Start from a plain Ubuntu base and add only what the task needs —
-the dogfooded SkillsBench tasks all begin with `FROM ubuntu:24.04`.
+The environment directory holds the `Dockerfile` and any seed data the agent
+reads at trial time. The agent works in `/app`. Start from a plain base and add
+only what the task needs:
 
 ```dockerfile
 # environment/Dockerfile
 FROM ubuntu:24.04
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Install Python + anything else the task needs.
-RUN apt-get update && apt-get install -y \
-    python3 \
-    python3-pip \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /root
-
-# Task-specific deps. Pin versions.
-RUN pip3 install --break-system-packages \
-    requests==2.32.3
-
-# Seed data the agent reads at trial time.
-COPY data.json /root/data.json
-
-# Optional: bundle a skill package the agent can discover.
-# COPY skills /root/skills
+RUN apt-get update -qq \
+ && apt-get install -y -qq python3 curl \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+RUN mkdir -p /logs/verifier /logs/agent /logs/artifacts
 ```
 
-The agent works inside `$BENCHFLOW_WORKSPACE` (default `/root`). Anything the
-verifier needs to see must be written under that path before the agent exits.
-Trial sandboxes start fresh per attempt.
+Anything the verifier needs to see must be written under `/app` before the agent
+exits. Trial sandboxes start fresh per attempt.
 
-An optional `environment/skills/` directory follows the
-[Agent Skills spec](https://agentskills.io/home): each subdirectory is one skill
-with its own `SKILL.md`, scripts, and references. Bundling skills with the task
-is the usual way to teach an agent the domain-specific moves your verifier
-expects.
+### Multi-container tasks
+
+A task may ship `environment/docker-compose.yaml` alongside the `Dockerfile`.
+The agent always runs in the `main` service; additional services become sibling
+containers on the same network — useful for CVE-style tasks where the agent
+attacks a separate target.
+
+```yaml
+# environment/docker-compose.yaml
+services:
+  main: {}            # agent container — limits/image injected
+  target:
+    image: vulhub/struts2-s2-001:latest
+    expose: ["8080"]
+```
+
+`main` reaches `target` by service name (`http://target:8080`). A verifier can
+inspect target-side state by setting `[verifier].service: target`, which runs
+`test.sh` inside that container. `environment/Dockerfile` is always required,
+even when `main` uses a prebuilt `image:`.
 
 ## verifier/
 
-The verifier runs after the agent finishes and writes three artifacts to
-`/logs/verifier/`:
+The runtime copies `verifier/` to `/verifier/` and runs it after the agent
+finishes. With no `verifier.md`, it runs `/verifier/test.sh`. With a
+`verifier.md`, it runs the selected strategy: `script` (a declared command),
+`llm-judge`, `agent-judge`, or `reward-kit`.
 
-- `reward.txt` — a single float, one of `0.0` or `1.0` for binary checks (or a real number in [0,1] for graded ones).
-- `reward.json` — `{ "reward": <float> }`.
-- `ctrf.json` — pytest's [CTRF](https://ctrf.io/) details for per-check breakdowns.
+**Your verifier must write a reward artifact.** Script verifiers write a single
+float in `[0.0, 1.0]` to `/logs/verifier/reward.txt`; strategies may also write
+`reward.json` and `reward-details.json`. A nonzero exit with no fresh reward
+file is treated as infrastructure failure.
 
-`verifier/test.sh` is a small shim that runs pytest against `test_outputs.py` and
-writes those artifacts — copy it verbatim from the template. Put your real checks
-in `test_outputs.py`:
+| Path | Contents |
+|---|---|
+| `/app/` | Agent's working directory |
+| `/verifier/` | Your `verifier/` directory |
+| `/oracle/` | `oracle/` files (oracle runs only) |
+| `/logs/verifier/` | Write `reward.txt` (and optionally `ctrf.json`) here |
 
-```python
-# verifier/test_outputs.py — pytest tests the trial's outputs.
-# Passing → reward 1.0; any failure → reward 0.0. Use one test class
-# per check group so partial-credit cases stay readable.
-import json, os
-from pathlib import Path
-import pytest
-
-WORKSPACE = Path(os.environ.get("BENCHFLOW_WORKSPACE", "/root"))
-ANSWER_FILE = WORKSPACE / "answer.json"
-
-class TestAnswerFileExists:
-    def test_file_exists(self):
-        assert ANSWER_FILE.exists(), f"Answer file not found at {ANSWER_FILE}"
-
-    def test_file_is_valid_json(self):
-        with open(ANSWER_FILE) as f:
-            try:
-                json.load(f)
-            except json.JSONDecodeError as e:
-                pytest.fail(f"Answer file is not valid JSON: {e}")
-
-class TestAnswerContent:
-    def test_result_matches_expected(self):
-        with open(ANSWER_FILE) as f:
-            data = json.load(f)
-        assert data["result"] == 42, f"Expected 42, got {data['result']}"
-```
-
-The `verifier.md` file alongside the tests declares the rubric the pytest results
-roll up into, and gives reviewers a plain-language description for edge cases.
-Schema:
-
-```yaml
----
-document_version: '0.3'
-verifier:
-  name: your-task-verifier
-  default_strategy: pytest
-  strategies:
-    pytest:
-      type: script
-      command: ./test.sh
-  rubric:
-    combine: weighted_sum
-    dimensions:
-      correctness:
-        weight: 1.0
-        source: pytest
-  outputs:
-    reward_text: /logs/verifier/reward.txt
-    reward_json: /logs/verifier/reward.json
-    details_json: /logs/verifier/ctrf.json
----
-
-## role:reviewer
-
-State what a passing trial looks like in plain language. Human reviewers
-read this when grading edge cases the pytest tests can't decide alone.
-```
-
-The verifier runs in its own container by default with no network access.
-Declare `verifier.network_mode: public` in the frontmatter only if the verifier
-calls an LLM judge or external API.
-
-## oracle/
-
-The oracle is a reference solution. Its job is to prove the task is reachable:
-when run under the same environment, it must score a passing reward (1.0 for
-binary checks). Reviewers re-run the oracle as part of acceptance, and CI re-runs
-it on every change to the environment image.
+### Pure bash
 
 ```bash
 #!/bin/bash
-# oracle/solve.sh — reference solution. Runs in the same container the
-# agent uses. Must achieve a passing score so reviewers can confirm the
-# task is solvable; CI re-runs it on every image bump.
-set -e
-WORKSPACE="${BENCHFLOW_WORKSPACE:-/root}"
-mkdir -p "$WORKSPACE"
+REWARD=0
+if [ -f /app/hello.txt ] && [ "$(tr -d '\n' < /app/hello.txt)" = "Hello, world!" ]; then
+    REWARD=1
+fi
+echo "$REWARD" > /logs/verifier/reward.txt
+```
 
-cat > "$WORKSPACE/answer.json" << 'JSON'
-{
-  "result": 42
-}
-JSON
+### pytest
+
+```bash
+#!/bin/bash
+curl -LsSf https://astral.sh/uv/0.9.7/install.sh | sh
+source $HOME/.local/bin/env
+
+uvx \
+  --with pytest==8.4.1 \
+  --with pytest-json-ctrf==0.3.5 \
+  pytest --ctrf /logs/verifier/ctrf.json /verifier/test_outputs.py -rA
+
+if [ $? -eq 0 ]; then echo 1; else echo 0; fi > /logs/verifier/reward.txt
+```
+
+### Partial credit
+
+```bash
+python3 -c "print($PASSED / $TOTAL)" > /logs/verifier/reward.txt
+```
+
+**Security:** don't let the agent write to `/logs/verifier/reward.txt` or modify
+`/verifier/test.sh`. For tasks running arbitrary code, set
+`network_mode: no-network` and verify output files only.
+
+## oracle/
+
+A reference solution that proves the task is solvable. With
+`bench eval create --agent oracle`, the runtime copies `oracle/` to `/oracle/`
+and runs `oracle/solve.sh` instead of an agent. It must score a passing reward.
+`solve.sh` has the same filesystem access as the agent — write only to `/app/`.
+Reviewers and CI re-run it on every environment change.
+
+```bash
+#!/bin/bash
+echo "Hello, world!" > /app/hello.txt
 ```
 
 Keep the oracle as simple as the task allows — it is documentation as much as a
-regression check. A long, clever oracle usually means the task is doing too much.
+regression check.
 
-## Validate locally
+## CLI
 
-Use the `bench` CLI to validate before opening a PR. Two levels matter for
-authors:
+Use the `bench` CLI to scaffold, validate, and run tasks:
 
 ```bash
-# 1. Schema-only — fast, no Docker required
-bench tasks check ./tasks/your-task-name --level schema
+# Scaffold a new task
+bench tasks init my-task
+bench tasks init my-task --no-pytest --no-oracle
 
-# 2. Publication-grade — builds the image, runs the oracle, scores it
-bench tasks check ./tasks/your-task-name --level publication-grade
+# Expand a minimal task.md into the canonical contract
+bench tasks normalize tasks/my-task/ --write
+
+# Validate — schema, structure, runtime support, publication shape
+bench tasks check tasks/my-task/ --level schema
+bench tasks check tasks/my-task/
+bench tasks check tasks/my-task/ --level publication-grade --sandbox docker
+bench tasks check tasks/my-task/ --level acceptance
+
+# Confirm the oracle scores reward = 1.0
+bench eval create --tasks-dir tasks/my-task/ --agent oracle --sandbox docker
+
+# Run a real agent
+bench eval create --tasks-dir tasks/my-task/ --agent gemini --sandbox daytona
 ```
 
-Schema mode catches frontmatter typos, missing required fields, and unknown
-headings. Publication-grade additionally verifies the full submission contract —
-including that `verifier/rubrics/` contains at least one rubric file. CI runs
-schema on every PR and publication-grade on PRs that touch `tasks/`; running the
-same command locally first cuts the review loop.
+`--level schema` checks only the authoring entrypoint and prompt parse.
+`--level publication-grade` checks the native package contract for registry-ready
+authoring (native `oracle/`, `verifier/verifier.md`, rubric files, selected
+strategy artifacts, and an explicit reward-JSON output contract).
+`--level acceptance` adds static evidence checks for oracle proof, verifier
+stability, and calibration; `--level acceptance-live --sandbox <backend>` runs
+that evidence through a real sandbox. CI runs schema on every PR and the higher
+levels on PRs that touch `tasks/`.
 
 Install the CLI once:
 
 ```bash
-# Recommended: uv tool install (isolated, fast)
-uv tool install benchflow
-
-# Or with pip
+uv tool install benchflow   # recommended (isolated, fast)
+# or
 pip install benchflow
 ```
 
@@ -357,7 +290,7 @@ pip install benchflow
 
 Open a pull request against this repository with your task directory under
 `tasks/`. Include the local `publication-grade` output in the PR description so
-reviewers know it built and passed against your machine. Discussion happens on
+reviewers know it built and passed on your machine. Discussion happens on
 [Discord](https://discord.gg/mZ9Rc8q8W3) and in the PR thread.
 
 Accepted tasks are released openly. We post-train a Qwen3-8B model across the

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,365 @@
+# task.md specification
+
+How to author a PostTrain Arena submission. This is the reference; the body of
+each section is what reviewers compare against. The same content is rendered at
+[posttrain.com/docs/spec](https://posttrain.com/docs/spec).
+
+A submission is four pieces in one directory: a `task.md`, an `environment/`, a
+`verifier/`, and an `oracle/`.
+
+## Contents
+
+- [Overview](#overview)
+- [Submission layout](#submission-layout)
+- [task.md](#taskmd)
+- [environment/](#environment)
+- [verifier/](#verifier)
+- [oracle/](#oracle)
+- [Validate locally](#validate-locally)
+- [Submit](#submit)
+
+## Overview
+
+PostTrain Arena tasks are *self-contained*: a fresh checkout plus Docker is
+enough to build the environment, run an agent, and score the result. There is no
+hidden runtime config; every limit and scoring rule lives in the submission
+directory.
+
+The format is built on `task.md` — a single human-authored file with YAML
+frontmatter (limits, metadata, optional multi-agent structure) and a Markdown
+body (the prompt, plus optional per-scene or per-role guidance). It expands
+through defaults into the same canonical contract that the eval pipeline
+consumes, so a minimal author file stays small but a richer one can spell out
+scenes, roles, and a simulated user without leaving the file.
+
+## Submission layout
+
+```
+tasks/
+└─ your-task-name/
+   ├─ task.md                    # required — frontmatter + prompt
+   ├─ environment/
+   │  ├─ Dockerfile              # required — built fresh per task
+   │  ├─ <seed-data>             # optional — any files the agent reads
+   │  └─ skills/                 # optional — agent-discoverable skill packages
+   ├─ verifier/
+   │  ├─ test.sh                 # required — pytest runner shim (boilerplate)
+   │  ├─ test_outputs.py         # required — the actual checks
+   │  ├─ verifier.md             # required — rubric declaration (frontmatter)
+   │  └─ rubrics/
+   │     └─ verifier.md          # required — plain-language pass criteria
+   └─ oracle/
+      └─ solve.sh                # required — produces a passing trial
+```
+
+Naming convention: `<env-or-domain>-<short-description>` — for example
+`gmail-workflow-delegation` or `finance-weighted-gdp-calc`. Category, modality,
+and any safety qualifier live in the frontmatter, not the directory name.
+
+The fastest way to start is `cp -R tasks/template tasks/your-task-name` from a
+fresh checkout. The three `skillsbench-*` tasks in the repo are the working
+references — copy the parts you need from them.
+
+## task.md
+
+Two halves separated by a `---` fence: YAML frontmatter on top, Markdown body
+below. Frontmatter declares limits and metadata; the body holds the prompt and,
+optionally, per-scene or per-role instructions and a user persona.
+
+### Minimal example
+
+```yaml
+---
+version: "1.0"
+metadata:
+  author_name: Ada Lovelace
+  author_email: ada@example.com
+  category: sciences
+  difficulty: medium
+  tags: [calculation, spreadsheet]
+agent:
+  timeout_sec: 900
+verifier:
+  timeout_sec: 180
+environment:
+  cpus: 1
+  memory_mb: 4096
+---
+
+## prompt
+
+State the task here. One short paragraph that the agent will read first,
+followed by any structured detail it needs.
+```
+
+### Frontmatter reference
+
+All fields are optional unless marked required. Limits default to safe values
+(verifier 180s, agent 900s, 1 CPU, 4 GB RAM). Field names use snake_case
+throughout.
+
+- `version` (required) — schema version, currently `"1.0"`.
+- `metadata.author_name` + `author_email` (required) — contact for the contributor.
+- `metadata.category` (required) — one of the eight domains, e.g. `sciences`, `cybersecurity`, `office-knowledge-work`.
+- `metadata.difficulty` — `easy` | `medium` | `hard`.
+- `metadata.tags` — short string list, used for routing and filtering.
+- `agent.timeout_sec` — wall-clock budget for the agent.
+- `verifier.timeout_sec` — budget for the scoring run after the agent finishes.
+- `environment.cpus` / `memory_mb` / `storage_mb` — sandbox limits.
+- `environment.network_mode` — `no-network` (default), `allowlist` with `allowed_hosts`, or `public`.
+- `agents.roles` — optional named roles when the task is multi-agent (see below).
+- `scenes` — optional ordered list of scenes, each referencing one or more roles.
+- `user` — optional simulated-user model + stop rule when the agent needs a counterpart.
+
+### Body sections
+
+The body is Markdown with a small set of well-known headings. Anything not
+matching a known heading is passed through as authoring notes and ignored by the
+runtime.
+
+- `## prompt` (required) — what the agent sees first.
+- `## scene:<name>` — guidance shown when that scene starts, if you declared `scenes`.
+- `## role:<name>` — guidance shown to that role, if you declared `agents.roles`.
+- `## user-persona` — the simulated user's mindset, if you declared `user`.
+
+### Multi-agent example
+
+The richer form composes roles, scenes, and a simulated user in one file — the
+same authoring document the eval pipeline consumes directly:
+
+```yaml
+---
+version: "1.0"
+metadata:
+  author_name: benchflow
+  category: office-knowledge-work
+  difficulty: hard
+  tags: [multi-agent, planning]
+agent:
+  timeout_sec: 1200
+verifier:
+  timeout_sec: 240
+environment:
+  cpus: 2
+  memory_mb: 4096
+agents:
+  roles:
+    planner:
+      agent: claude-agent-acp
+      model: claude-sonnet-4-6
+    executor:
+      agent: codex-acp
+      model: gpt-5.5
+      reasoning_effort: high
+scenes:
+  - name: plan
+    turns: [{ role: planner }]
+  - name: implement
+    turns: [{ role: executor }]
+user:
+  model: claude-haiku
+  stop_rule: satisfied-or-5-rounds
+---
+
+## prompt
+
+Refactor the tiny service so it keeps the same public behavior while splitting
+request parsing, business logic, and output formatting into separate modules.
+
+## scene:plan
+
+Read the task, inspect the code, and write a concise implementation plan.
+
+## scene:implement
+
+Apply the plan. Run the verifier before finishing.
+
+## user-persona
+
+You are impatient and only reveal the order id if the agent asks for it
+specifically.
+```
+
+## environment/
+
+The environment directory holds the Dockerfile and any seed data the agent needs
+at trial time. Start from a plain Ubuntu base and add only what the task needs —
+the dogfooded SkillsBench tasks all begin with `FROM ubuntu:24.04`.
+
+```dockerfile
+# environment/Dockerfile
+FROM ubuntu:24.04
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install Python + anything else the task needs.
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /root
+
+# Task-specific deps. Pin versions.
+RUN pip3 install --break-system-packages \
+    requests==2.32.3
+
+# Seed data the agent reads at trial time.
+COPY data.json /root/data.json
+
+# Optional: bundle a skill package the agent can discover.
+# COPY skills /root/skills
+```
+
+The agent works inside `$BENCHFLOW_WORKSPACE` (default `/root`). Anything the
+verifier needs to see must be written under that path before the agent exits.
+Trial sandboxes start fresh per attempt.
+
+An optional `environment/skills/` directory follows the
+[Agent Skills spec](https://agentskills.io/home): each subdirectory is one skill
+with its own `SKILL.md`, scripts, and references. Bundling skills with the task
+is the usual way to teach an agent the domain-specific moves your verifier
+expects.
+
+## verifier/
+
+The verifier runs after the agent finishes and writes three artifacts to
+`/logs/verifier/`:
+
+- `reward.txt` — a single float, one of `0.0` or `1.0` for binary checks (or a real number in [0,1] for graded ones).
+- `reward.json` — `{ "reward": <float> }`.
+- `ctrf.json` — pytest's [CTRF](https://ctrf.io/) details for per-check breakdowns.
+
+`verifier/test.sh` is a small shim that runs pytest against `test_outputs.py` and
+writes those artifacts — copy it verbatim from the template. Put your real checks
+in `test_outputs.py`:
+
+```python
+# verifier/test_outputs.py — pytest tests the trial's outputs.
+# Passing → reward 1.0; any failure → reward 0.0. Use one test class
+# per check group so partial-credit cases stay readable.
+import json, os
+from pathlib import Path
+import pytest
+
+WORKSPACE = Path(os.environ.get("BENCHFLOW_WORKSPACE", "/root"))
+ANSWER_FILE = WORKSPACE / "answer.json"
+
+class TestAnswerFileExists:
+    def test_file_exists(self):
+        assert ANSWER_FILE.exists(), f"Answer file not found at {ANSWER_FILE}"
+
+    def test_file_is_valid_json(self):
+        with open(ANSWER_FILE) as f:
+            try:
+                json.load(f)
+            except json.JSONDecodeError as e:
+                pytest.fail(f"Answer file is not valid JSON: {e}")
+
+class TestAnswerContent:
+    def test_result_matches_expected(self):
+        with open(ANSWER_FILE) as f:
+            data = json.load(f)
+        assert data["result"] == 42, f"Expected 42, got {data['result']}"
+```
+
+The `verifier.md` file alongside the tests declares the rubric the pytest results
+roll up into, and gives reviewers a plain-language description for edge cases.
+Schema:
+
+```yaml
+---
+document_version: '0.3'
+verifier:
+  name: your-task-verifier
+  default_strategy: pytest
+  strategies:
+    pytest:
+      type: script
+      command: ./test.sh
+  rubric:
+    combine: weighted_sum
+    dimensions:
+      correctness:
+        weight: 1.0
+        source: pytest
+  outputs:
+    reward_text: /logs/verifier/reward.txt
+    reward_json: /logs/verifier/reward.json
+    details_json: /logs/verifier/ctrf.json
+---
+
+## role:reviewer
+
+State what a passing trial looks like in plain language. Human reviewers
+read this when grading edge cases the pytest tests can't decide alone.
+```
+
+The verifier runs in its own container by default with no network access.
+Declare `verifier.network_mode: public` in the frontmatter only if the verifier
+calls an LLM judge or external API.
+
+## oracle/
+
+The oracle is a reference solution. Its job is to prove the task is reachable:
+when run under the same environment, it must score a passing reward (1.0 for
+binary checks). Reviewers re-run the oracle as part of acceptance, and CI re-runs
+it on every change to the environment image.
+
+```bash
+#!/bin/bash
+# oracle/solve.sh — reference solution. Runs in the same container the
+# agent uses. Must achieve a passing score so reviewers can confirm the
+# task is solvable; CI re-runs it on every image bump.
+set -e
+WORKSPACE="${BENCHFLOW_WORKSPACE:-/root}"
+mkdir -p "$WORKSPACE"
+
+cat > "$WORKSPACE/answer.json" << 'JSON'
+{
+  "result": 42
+}
+JSON
+```
+
+Keep the oracle as simple as the task allows — it is documentation as much as a
+regression check. A long, clever oracle usually means the task is doing too much.
+
+## Validate locally
+
+Use the `bench` CLI to validate before opening a PR. Two levels matter for
+authors:
+
+```bash
+# 1. Schema-only — fast, no Docker required
+bench tasks check ./tasks/your-task-name --level schema
+
+# 2. Publication-grade — builds the image, runs the oracle, scores it
+bench tasks check ./tasks/your-task-name --level publication-grade
+```
+
+Schema mode catches frontmatter typos, missing required fields, and unknown
+headings. Publication-grade additionally verifies the full submission contract —
+including that `verifier/rubrics/` contains at least one rubric file. CI runs
+schema on every PR and publication-grade on PRs that touch `tasks/`; running the
+same command locally first cuts the review loop.
+
+Install the CLI once:
+
+```bash
+# Recommended: uv tool install (isolated, fast)
+uv tool install benchflow
+
+# Or with pip
+pip install benchflow
+```
+
+## Submit
+
+Open a pull request against this repository with your task directory under
+`tasks/`. Include the local `publication-grade` output in the PR description so
+reviewers know it built and passed against your machine. Discussion happens on
+[Discord](https://discord.gg/mZ9Rc8q8W3) and in the PR thread.
+
+Accepted tasks are released openly. We post-train a Qwen3-8B model across the
+accepted pool and score it on the private IndexBench suite. Standings will be
+published once Phase 1 begins.


### PR DESCRIPTION
Fills in the public repo so the GitHub link from the site lands on real docs instead of a stub.

- **README.md** — project overview: what PostTrain Arena is, how it works (contribute → post-train → score → rank), the eight domains, how to contribute a task (the four-piece submission), validate locally with the `bench` CLI, and submit.
- **SPEC.md** — the full `task.md` authoring reference, mirrored from posttrain.com/docs/spec (frontmatter schema, body sections, environment/verifier/oracle contracts, local validation).

All links point to posttrain.com and this repo; no external hub references.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or application code touched.
> 
> **Overview**
> Replaces the repo’s **one-line README stub** with a full **PostTrain Arena** landing page: what the competition is, contribute → post-train → IndexBench → rank, the eight `category` domains, the four-piece task layout under `tasks/`, local validation via `bench tasks check`, PR submission expectations, and links to the site, catalog, and Discord.
> 
> Adds **`SPEC.md`** as the in-repo **`task.md` authoring reference**: directory layout, frontmatter schema 1.3, body sections, `environment/` (including multi-container compose), `verifier/` strategies and reward artifacts, `oracle/`, and `bench` CLI levels from schema through publication-grade/acceptance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e25223ef1a22453821b8777f455395fa9c5fb3c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->