### PR TITLE
Clarify public pipeline status and contributor policies

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+- What changed?
+- Why is this the smallest appropriate change?
+
+## Validation
+
+- [ ] Existing task checks pass when relevant
+- [ ] Pipeline tests and documented CLI checks pass when relevant
+- [ ] No credentials, private eval content, checkpoints, or raw provider dumps are included
+- [ ] Dataset, model, and external dependency revisions are pinned when relevant
+- [ ] Public docs and evidence boundaries are updated when behavior or claims change
+
+## Spend and external systems
+
+List any GPU/API/Daytona spendful validation performed. If none, write
+`No spendful validation` and identify what remains manual.

--- a/.github/workflows/benchflow-posttrain-pipeline.yml
+++ b/.github/workflows/benchflow-posttrain-pipeline.yml
@@ -5,16 +5,26 @@ on:
     paths:
       - "pipelines/benchflow-task-posttrain/**"
       - "docs/training-pipeline.md"
+      - "docs/README.md"
       - "README.md"
       - "CONTRIBUTING.md"
+      - "SECURITY.md"
+      - "SUPPORT.md"
+      - "CODE_OF_CONDUCT.md"
+      - ".github/pull_request_template.md"
       - ".github/workflows/benchflow-posttrain-pipeline.yml"
   push:
     branches: [main]
     paths:
       - "pipelines/benchflow-task-posttrain/**"
       - "docs/training-pipeline.md"
+      - "docs/README.md"
       - "README.md"
       - "CONTRIBUTING.md"
+      - "SECURITY.md"
+      - "SUPPORT.md"
+      - "CODE_OF_CONDUCT.md"
+      - ".github/pull_request_template.md"
       - ".github/workflows/benchflow-posttrain-pipeline.yml"
 
 concurrency:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,38 @@
+# Contributor Covenant Code of Conduct
+
+## Our pledge
+
+We pledge to make participation in PostTrain Arena a harassment-free experience
+for everyone, regardless of age, body size, disability, ethnicity, sex
+characteristics, gender identity and expression, experience level, education,
+socioeconomic status, nationality, personal appearance, race, caste, color,
+religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our standards
+
+Positive behavior includes demonstrating empathy, respecting differing
+viewpoints, giving and accepting constructive feedback, taking responsibility,
+and focusing on what is best for the community.
+
+Unacceptable behavior includes sexualized language or attention, trolling,
+insults, personal or political attacks, public or private harassment,
+publishing others' private information, and other conduct reasonably considered
+inappropriate in a professional setting.
+
+## Enforcement
+
+Project maintainers may remove, edit, or reject comments, commits, code, issues,
+and other contributions that do not align with this code. They may temporarily
+or permanently restrict participation for inappropriate, threatening,
+offensive, or harmful behavior.
+
+Report conduct concerns privately to `labs@benchflow.ai`. Reports will be
+reviewed promptly and handled with appropriate confidentiality.
+
+## Attribution
+
+This code is adapted from the Contributor Covenant, version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,12 @@ baseline trained with the identical recipe, with paired bootstrap
 confidence intervals. Track 1 packages are evaluated by pass@1 of a
 frozen reference agent — no training, no internet.
 
+Qwen3-8B is the current **draft competition recipe**, not the model used by the
+checked-in reference smoke. The public implementation currently pins Qwen3-4B
+to validate the operator contract at smaller scale. See
+[`docs/training-pipeline.md`](./docs/training-pipeline.md) for exact executable
+behavior and evidence boundaries.
+
 **Phases.** Phase 0 (warm-up): public sample only, leaderboard hidden.
 Phase 1 (development): full entries accepted, public-sample scoring
 shown live. Phase 2 (final): submissions frozen, private-suite

--- a/README.md
+++ b/README.md
@@ -36,6 +36,27 @@ Status: proposal under review; rules are draft until the starting kit
 ships. This repo is the starting-kit preview and the future home of
 team submissions.
 
+## Implementation status
+
+The competition rules and the checked-in training implementation have different
+stability levels:
+
+- **Draft competition recipe:** the proposal currently names Qwen3-8B and a
+  fixed organizer recipe. That model, compute budget, and final scoring setup
+  remain subject to the published competition rules.
+- **Reproducible public reference:**
+  [`pipelines/benchflow-task-posttrain/`](./pipelines/benchflow-task-posttrain)
+  currently provides a pinned Qwen3-4B BenchFlow + TRL smoke recipe. It is the
+  supported code path for exercising the task-list, SFT, reward-gate, optional
+  GRPO, and held-out reporting contract.
+- **Evidence boundary:** the reproduced smoke validates pipeline mechanics but
+  measured `0.0 → 0.0`; it is not a quality-lift or final competition-scale
+  result.
+
+When draft rules and implementation details differ, treat the rules as product
+design and the [training guide](./docs/training-pipeline.md) as the current
+executable contract.
+
 ## What is in this repo
 
 - [`starting-kit/`](./starting-kit) — the task template and
@@ -78,6 +99,10 @@ reference is at <https://posttrain.com/docs/spec>.
 
 Organizers and researchers reproducing the training side should start with
 the [training pipeline guide](./docs/training-pipeline.md).
+
+Project policies: [documentation map](./docs/README.md),
+[security](./SECURITY.md), [support](./SUPPORT.md), and
+[code of conduct](./CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security policy
+
+## Report a vulnerability
+
+Do not open a public issue for vulnerabilities, leaked credentials, sandbox
+escapes, verifier bypasses, prompt or dataset leakage, or unsafe task assets.
+Email `labs@benchflow.ai` with:
+
+- the affected path, version, or commit
+- reproduction steps and expected impact
+- whether credentials, private evaluation data, or third-party systems are at risk
+- a safe contact method for follow-up
+
+We will acknowledge a complete report within five business days and coordinate
+disclosure after a fix or mitigation is available.
+
+## Scope
+
+Security-sensitive surfaces include:
+
+- participant-provided Dockerfiles, scripts, skills, and task assets
+- verifier and oracle isolation
+- Daytona or Docker sandbox lifecycle
+- provider and Hugging Face credentials
+- private held-out evaluation data
+- generated trajectories, checkpoints, and model artifacts
+
+Never commit secrets, raw provider responses containing secrets, checkpoints,
+private eval tasks, or unreviewed job dumps. Use environment variables or a
+secret manager, pin external revisions, and keep generated runs in ignored
+directories.
+
+The competition is a proposal and does not currently provide a production SLA.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,20 @@
+# Support
+
+Use the channel that matches the request:
+
+- **Environment authoring and task-contract questions:** open a GitHub issue
+  with a minimal task-package example, or ask in the project Discord.
+- **Training-pipeline bugs:** open a GitHub issue with the recipe revision, task
+  IDs, command, sanitized logs, and whether the failure reproduces with
+  `--dry-run`.
+- **Competition rules or private submission questions:** email
+  `labs@benchflow.ai`.
+- **Security, leaked credentials, sandbox escapes, or private eval exposure:**
+  follow [`SECURITY.md`](SECURITY.md) and do not file a public issue.
+
+Before requesting help, run the relevant no-spend checks documented in
+[`CONTRIBUTING.md`](CONTRIBUTING.md) and
+[`docs/training-pipeline.md`](docs/training-pipeline.md). Remove secrets and
+private task content from all logs.
+
+This repository does not currently offer a production support SLA.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# Documentation map
+
+| Document | Audience | Purpose |
+|---|---|---|
+| [`../README.md`](../README.md) | Everyone | Competition overview, repository map, and implementation status |
+| [`../CONTRIBUTING.md`](../CONTRIBUTING.md) | Contributors | Submission rules, environment authoring, reviews, and pipeline contributions |
+| [`training-pipeline.md`](training-pipeline.md) | Organizers and researchers | Canonical BenchFlow + TRL operator guide, configuration, execution, artifacts, and evidence limits |
+| [`../starting-kit/README.md`](../starting-kit/README.md) | Environment authors | Task package template and worked examples |
+| [`../submissions/README.md`](../submissions/README.md) | Teams | Team-entry layout and submission manifest |
+| [`../SECURITY.md`](../SECURITY.md) | Security reporters | Private vulnerability reporting and secret-handling expectations |
+| [`../SUPPORT.md`](../SUPPORT.md) | Users | Where to ask usage, competition, and incident questions |
+
+The competition recipe is still draft. The implementation under
+`pipelines/benchflow-task-posttrain/` and the training guide define the current
+reproducible software contract.


### PR DESCRIPTION
## Summary

- distinguish the draft competition-scale Qwen3-8B recipe from the reproducible Qwen3-4B public pipeline smoke
- state the zero-lift evidence boundary prominently so pipeline validation is not presented as model-quality proof
- add a documentation map, security policy, support guide, code of conduct, and PR checklist
- make policy and documentation changes trigger the pipeline contracts workflow

## Validation

- all existing starting-kit structural checks passed
- submission validation passed
- pipeline Ruff, formatting, compilation, and 10 tests passed
- workflow YAML parsed successfully
- all relative Markdown links resolve
- clean Python 3.12 install and documented `validate`, `plan`, and `run --dry-run` commands passed
- changed-file secret, internal-path, and wrong-repository URL scan passed

## Scope

This PR does not change training behavior or competition rules. It makes the current implementation status, support boundaries, and contributor expectations explicit.
