### PR TITLE
Align public docs with pipeline architecture and OpenEnv status

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@
 - [ ] No credentials, private eval content, checkpoints, or raw provider dumps are included
 - [ ] Dataset, model, and external dependency revisions are pinned when relevant
 - [ ] Public docs and evidence boundaries are updated when behavior or claims change
+- [ ] Compatibility changes update `docs/architecture-status.md` and include an end-to-end contract test
 
 ## Spend and external systems
 

--- a/.github/workflows/benchflow-posttrain-pipeline.yml
+++ b/.github/workflows/benchflow-posttrain-pipeline.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "pipelines/benchflow-task-posttrain/**"
       - "docs/training-pipeline.md"
+      - "docs/architecture-status.md"
       - "docs/README.md"
       - "README.md"
       - "CONTRIBUTING.md"
@@ -18,6 +19,7 @@ on:
     paths:
       - "pipelines/benchflow-task-posttrain/**"
       - "docs/training-pipeline.md"
+      - "docs/architecture-status.md"
       - "docs/README.md"
       - "README.md"
       - "CONTRIBUTING.md"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,11 @@ The full authoring reference lives at
 <https://posttrain.com/docs/spec>; this file is the short version with
 links to the right places.
 
+Before changing runtime or compatibility claims, read
+[`docs/architecture-status.md`](./docs/architecture-status.md). The current
+training implementation uses BenchFlow + TRL. OpenEnv compatibility and HF Jobs
+execution are roadmap items, not current repository features.
+
 ## Contributing to the organizer training pipeline
 
 The public training implementation lives under
@@ -44,7 +49,9 @@ posttrainarena-train run \
 
 Never commit checkpoints, trajectories, raw provider responses, or secrets.
 See the [operator guide](./docs/training-pipeline.md) for the complete runtime
-and artifact contract.
+and artifact contract. Do not label a change OpenEnv-compatible unless it meets
+the lifecycle acceptance criteria in the
+[architecture/status document](./docs/architecture-status.md).
 
 ## How submission works
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,15 @@ stability levels:
 - **Evidence boundary:** the reproduced smoke validates pipeline mechanics but
   measured `0.0 → 0.0`; it is not a quality-lift or final competition-scale
   result.
+- **OpenEnv:** compatibility is planned but **not implemented**. The repository
+  has no OpenEnv client/server adapter, `openenv.yaml`, lifecycle test, or HF
+  Jobs path today.
 
 When draft rules and implementation details differ, treat the rules as product
-design and the [training guide](./docs/training-pipeline.md) as the current
-executable contract.
+design, the [architecture/status document](./docs/architecture-status.md) as the
+compatibility source of truth, and the
+[training guide](./docs/training-pipeline.md) as the current executable
+contract.
 
 ## What is in this repo
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,10 +24,16 @@ Security-sensitive surfaces include:
 - provider and Hugging Face credentials
 - private held-out evaluation data
 - generated trajectories, checkpoints, and model artifacts
+- future protocol adapters, including any OpenEnv server/client boundary
 
 Never commit secrets, raw provider responses containing secrets, checkpoints,
 private eval tasks, or unreviewed job dumps. Use environment variables or a
 secret manager, pin external revisions, and keep generated runs in ignored
 directories.
+
+The current repository has no OpenEnv server. Any future adapter must preserve
+sandbox isolation across resets, avoid exposing verifier secrets or private
+evaluation data through observations/state, and include an end-to-end security
+test before compatibility is claimed.
 
 The competition is a proposal and does not currently provide a production SLA.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -7,6 +7,10 @@ Use the channel that matches the request:
 - **Training-pipeline bugs:** open a GitHub issue with the recipe revision, task
   IDs, command, sanitized logs, and whether the failure reproduces with
   `--dry-run`.
+- **OpenEnv integration:** first check
+  [`docs/architecture-status.md`](docs/architecture-status.md). Compatibility is
+  not currently implemented; proposals should include a real OpenEnv
+  client/server lifecycle and isolation test rather than only format conversion.
 - **Competition rules or private submission questions:** email
   `labs@benchflow.ai`.
 - **Security, leaked credentials, sandbox escapes, or private eval exposure:**

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 | Document | Audience | Purpose |
 |---|---|---|
 | [`../README.md`](../README.md) | Everyone | Competition overview, repository map, and implementation status |
+| [`architecture-status.md`](architecture-status.md) | Everyone | Canonical architecture, ownership boundaries, compatibility matrix, and roadmap |
 | [`../CONTRIBUTING.md`](../CONTRIBUTING.md) | Contributors | Submission rules, environment authoring, reviews, and pipeline contributions |
 | [`training-pipeline.md`](training-pipeline.md) | Organizers and researchers | Canonical BenchFlow + TRL operator guide, configuration, execution, artifacts, and evidence limits |
 | [`../starting-kit/README.md`](../starting-kit/README.md) | Environment authors | Task package template and worked examples |
@@ -11,5 +12,7 @@
 | [`../SUPPORT.md`](../SUPPORT.md) | Users | Where to ask usage, competition, and incident questions |
 
 The competition recipe is still draft. The implementation under
-`pipelines/benchflow-task-posttrain/` and the training guide define the current
-reproducible software contract.
+`pipelines/benchflow-task-posttrain/` defines executable behavior, while
+[`architecture-status.md`](architecture-status.md) defines compatibility and
+roadmap status. OpenEnv compatibility and HF Jobs execution are not currently
+implemented.

--- a/docs/architecture-status.md
+++ b/docs/architecture-status.md
@@ -1,0 +1,128 @@
+# Architecture and implementation status
+
+This document separates the PostTrain Arena vision from what is implemented in
+the public repository today. It is the source of truth for compatibility and
+roadmap claims.
+
+## Vision
+
+PostTrain Arena evaluates the quality of contributed agent environments by
+holding the model recipe and held-out evaluation suite fixed:
+
+```text
+team task corpus
+    -> organizer validation and verifier audit
+    -> fixed SFT and optional RL recipe
+    -> trained team checkpoint
+    -> sealed held-out evaluation
+    -> lift over a fixed reference checkpoint
+```
+
+The competition proposal currently describes a Qwen3-8B organizer recipe and a
+private BenchFlow Signals evaluation suite. Those are draft competition rules,
+not frozen implementation details.
+
+## Current public implementation
+
+The supported executable reference is the Qwen3-4B pipeline under
+[`pipelines/benchflow-task-posttrain/`](../pipelines/benchflow-task-posttrain):
+
+```text
+PostTrain task lists and pinned HF snapshots
+    -> BenchFlow task loading and sandbox lifecycle
+    -> BenchFlow run_bash / submit agent harness
+    -> verifier-approved teacher trajectories
+    -> TRL LoRA SFT and merged checkpoint
+    -> BenchFlow reward gate on training tasks
+    -> optional TRL GRPO
+    -> held-out BenchFlow evaluation and paired lift report
+```
+
+The final machine-readable contract is:
+
+```text
+runs/<run-name>/reports/score.json
+```
+
+The checked-in smoke validates this orchestration and its zero-reward skip
+path. It measured `0.0 -> 0.0`, so it is not evidence of model-quality lift or
+competition-scale readiness.
+
+## Ownership boundaries
+
+| Layer | Current owner | Responsibility |
+|---|---|---|
+| Submission format | PostTrain Arena | `task.md`, `environment/`, `verifier/`, `oracle/`, and team manifests |
+| Local author validation | PostTrain Arena | Structural checks, Docker oracle replay, and empty-trial rejection |
+| Task/runtime/eval system | BenchFlow | Task snapshots, Daytona/Docker lifecycle, tools, verifier execution, rewards, and artifacts |
+| Optimization | TRL | LoRA SFT and GRPO |
+| Tracking | W&B | Training loss and GPU utilization when enabled |
+| Task/model storage | Hugging Face Hub | Pinned snapshots and model/artifact publication when configured |
+
+## Compatibility matrix
+
+| Surface | Status | Evidence or boundary |
+|---|---|---|
+| PostTrain `task.md` packages | Implemented | Starting-kit examples, structural CI, and local Docker harness |
+| BenchFlow task-list training/eval | Implemented | Public pipeline, tests, CLI dry-run, and completed H100 smoke |
+| Docker runtime | Implemented | Local author harness and BenchFlow runtime option |
+| Daytona runtime | Implemented in pipeline | BenchFlow runtime option; credentials required for real execution |
+| TRL SFT | Implemented | Tool-aware LoRA SFT and merged checkpoint path |
+| TRL GRPO | Implemented and reward-gated | Runs only after a training-task reward gate passes |
+| Harbor | Not a dependency | No Harbor adapter or trajectory translation is used |
+| OpenEnv client/server lifecycle | **Not implemented** | No `openenv` dependency, `openenv.yaml`, `EnvClient`, served environment, or lifecycle test exists |
+| HF Jobs execution | **Not implemented** | No HF Jobs launcher or deployment workflow exists |
+| Final Qwen3-8B competition recipe | Draft | Current reproducible reference pins Qwen3-4B |
+| Demonstrated model-quality lift | Not yet | Reproduced smoke measured zero lift |
+
+## OpenEnv roadmap
+
+The current repository is **not OpenEnv-compatible**. A BenchFlow environment
+method named `reset` is not evidence of OpenEnv compatibility. Credible
+compatibility requires an actual OpenEnv client/server surface and an
+end-to-end lifecycle test.
+
+The minimum adapter should provide:
+
+```text
+integrations/openenv/
+  openenv.yaml
+  models.py
+  client.py
+  server/
+    app.py
+    posttrain_environment.py
+  tests/
+    test_lifecycle.py
+    test_task_adapter.py
+```
+
+Acceptance requires all of the following:
+
+1. Start an OpenEnv-compatible server around a checked-in PostTrain task.
+2. Connect with the real OpenEnv client.
+3. Call `reset`, execute one or more `step` actions, and retrieve state.
+4. Terminate or submit the episode and run the existing verifier.
+5. Return reward, completion state, and artifact references through OpenEnv
+   models.
+6. Reset again and prove sandbox isolation.
+7. Pass a no-secret Docker lifecycle test in CI.
+8. Document the mapping between one-shot PostTrain trials and long-lived
+   OpenEnv episodes.
+
+The related upstream discussion is
+[huggingface/OpenEnv#898](https://github.com/huggingface/OpenEnv/issues/898).
+That issue proposes validation support inside OpenEnv; it does not make this
+repository OpenEnv-compatible.
+
+## Documentation precedence
+
+Use this order when documents appear to differ:
+
+1. Current code and tests under `pipelines/benchflow-task-posttrain/`
+2. This architecture/status document
+3. [`training-pipeline.md`](training-pipeline.md)
+4. Draft competition language in the root README and contribution guide
+
+Any PR that changes a compatibility status, runtime, model recipe, output
+schema, or evidence claim must update this document in the same change.

--- a/docs/training-pipeline.md
+++ b/docs/training-pipeline.md
@@ -6,6 +6,10 @@ implementation under
 It accepts explicit training and held-out evaluation task lists and produces a
 versioned score report after SFT and optional GRPO.
 
+For the broader system boundaries and compatibility matrix, including the
+current absence of an OpenEnv adapter, see
+[`architecture-status.md`](architecture-status.md).
+
 ```text
 training task list + held-out eval task list + pinned TOML recipe
     -> snapshot task packages from Hugging Face
@@ -23,6 +27,10 @@ BenchFlow owns task snapshots, Daytona or Docker sandboxes, the `run_bash` and
 `submit` tools, verifiers, reward extraction, rollout artifacts, and paired
 evaluation. TRL owns SFT and GRPO optimization. The pipeline is Harbor-free and
 does not translate Harbor trajectories.
+
+This is a BenchFlow runtime integration, not an OpenEnv implementation. It does
+not expose an OpenEnv `EnvClient`, served `Environment`, `openenv.yaml`, or HF
+Jobs launcher.
 
 ## Public contract
 

--- a/pipelines/benchflow-task-posttrain/README.md
+++ b/pipelines/benchflow-task-posttrain/README.md
@@ -3,6 +3,11 @@
 This is the public, reproducible training path for running SFT and conditional
 GRPO over BenchFlow-compatible task suites.
 
+The repository-wide architecture and compatibility status is documented in
+[`docs/architecture-status.md`](../../docs/architecture-status.md). In
+particular, this package does not currently provide OpenEnv compatibility or an
+HF Jobs execution path.
+
 The interface is intentionally small:
 
 ```text

--- a/starting-kit/README.md
+++ b/starting-kit/README.md
@@ -1,5 +1,15 @@
 # PostTrain Arena — starting kit
 
+This directory defines the participant-facing **PostTrain task package** format.
+It is intentionally runnable with Python and Docker and does not require
+BenchFlow, TRL, or OpenEnv for authoring checks.
+
+Organizer training later consumes selected task packages through the public
+BenchFlow + TRL pipeline. The repository does **not** currently expose these
+packages as OpenEnv client/server environments. See
+[`docs/architecture-status.md`](../docs/architecture-status.md) for the exact
+boundary.
+
 Every directory under [`examples/`](./examples) is one **example task
 package**, authored
 by the organizing team to exercise the `task.md` contract (frontmatter

--- a/submissions/README.md
+++ b/submissions/README.md
@@ -1,5 +1,11 @@
 # Team submissions
 
+Submissions use the PostTrain Arena task-package and team-manifest contract.
+They are validated locally with the self-contained scripts in this repository;
+organizer training uses BenchFlow + TRL after intake. OpenEnv compatibility is
+not required for submissions and is not currently implemented by this repo.
+See [`docs/architecture-status.md`](../docs/architecture-status.md).
+
 A competition entry is **one directory here, owned by one team, on one
 track**. Submissions are bounded per team — you submit a corpus, not
 individual tasks, and the managed pipeline trains on your corpus as a


### PR DESCRIPTION
## Summary

- add a canonical architecture/status document covering the PostTrain submission format, BenchFlow runtime/eval ownership, TRL optimization, current Qwen3-4B reference, and draft competition recipe
- add a compatibility matrix that explicitly marks OpenEnv client/server support and HF Jobs execution as not implemented
- define the minimum OpenEnv adapter acceptance contract instead of treating similarly named `reset` methods as compatibility
- align the root README, contributor guide, operator guide, package README, starting kit, submission guide, support, security, PR template, and CI path triggers

## Current truth documented

- PostTrain `task.md` packages: implemented
- BenchFlow + TRL SFT/gated-GRPO pipeline: implemented
- Docker and Daytona runtime paths: implemented through the current interfaces
- Harbor: not a dependency
- OpenEnv adapter: not implemented
- HF Jobs execution: not implemented
- Qwen3-8B competition recipe: draft
- Qwen3-4B reference pipeline: reproducible
- demonstrated model-quality lift: not yet; completed smoke measured `0.0 -> 0.0`

## Validation

- all existing starting-kit structural checks passed
- submission validation passed
- pipeline Ruff, formatting, compilation, and 10 tests passed
- workflow YAML parsed successfully
- all public relative Markdown links resolve
- architecture assertions verify the compatibility matrix and reject false OpenEnv claims
- clean Python 3.12 install and documented `validate`, `plan`, and `run --dry-run` commands passed
- changed-file secret, internal-path, and wrong-repository URL scan passed
