### PR TITLE
Add OpenEnv protocol adapter

### DIFF
--- a/.github/workflows/benchflow-posttrain-pipeline.yml
+++ b/.github/workflows/benchflow-posttrain-pipeline.yml
@@ -36,7 +36,7 @@ concurrency:
 jobs:
   contracts:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
@@ -48,17 +48,20 @@ jobs:
         run: >-
           python -m py_compile
           pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/*.py
+          pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/openenv/*.py
       - name: Test no-spend contracts
         run: python -m pytest pipelines/benchflow-task-posttrain/tests -q
       - name: Exercise documented CLI
         working-directory: pipelines/benchflow-task-posttrain
         run: |
           posttrainarena-train validate --config configs/qwen3-4b-data-agent-smoke.toml
+          posttrainarena-train validate \
+            --config configs/qwen3-4b-data-agent-openenv-smoke.toml
           posttrainarena-train plan \
-            --config configs/qwen3-4b-data-agent-smoke.toml \
+            --config configs/qwen3-4b-data-agent-openenv-smoke.toml \
             --run-name ci-plan > /tmp/posttrainarena-plan.json
           posttrainarena-train run \
-            --config configs/qwen3-4b-data-agent-smoke.toml \
+            --config configs/qwen3-4b-data-agent-openenv-smoke.toml \
             --run-name ci-dry-run \
             --dry-run > /tmp/posttrainarena-run.json
           python - <<'PY'
@@ -69,6 +72,9 @@ jobs:
           run = json.loads(Path("/tmp/posttrainarena-run.json").read_text())
           assert plan["train_task_count"] == 15
           assert plan["eval_task_count"] == 2
+          assert plan["runtime"]["integration"] == "openenv"
+          assert plan["grpo"]["run_policy"] == "always"
+          assert run["grpo_run_policy"] == "always"
           assert run["grpo_planned"] is True
           assert run["grpo_ran"] is False
           PY

--- a/docs/architecture-status.md
+++ b/docs/architecture-status.md
@@ -29,6 +29,7 @@ The supported executable reference is the Qwen3-4B pipeline under
 
 ```text
 PostTrain task lists and pinned HF snapshots
+    -> direct BenchFlow or OpenEnv protocol integration
     -> BenchFlow task loading and sandbox lifecycle
     -> BenchFlow run_bash / submit agent harness
     -> verifier-approved teacher trajectories
@@ -68,52 +69,62 @@ competition-scale readiness.
 | Docker runtime | Implemented | Local author harness and BenchFlow runtime option |
 | Daytona runtime | Implemented in pipeline | BenchFlow runtime option; credentials required for real execution |
 | TRL SFT | Implemented | Tool-aware LoRA SFT and merged checkpoint path |
-| TRL GRPO | Implemented and reward-gated | Runs only after a training-task reward gate passes |
+| TRL GRPO | Implemented | Reward-gated by default; explicit `always` policy supports zero-reward plumbing runs |
 | Harbor | Not a dependency | No Harbor adapter or trajectory translation is used |
-| OpenEnv client/server lifecycle | **Not implemented** | No `openenv` dependency, `openenv.yaml`, `EnvClient`, served environment, or lifecycle test exists |
+| OpenEnv client/server lifecycle | Implemented | Pinned dependency, served adapter, typed client, real lifecycle tests, finalization, state, and session isolation |
+| OpenEnv/BenchFlow Docker parity | Manually validated | Checked-in security task produced identical output and reward `1.0` through both integrations; CI uses a no-spend fake BenchFlow boundary |
 | HF Jobs execution | **Not implemented** | No HF Jobs launcher or deployment workflow exists |
 | Final Qwen3-8B competition recipe | Draft | Current reproducible reference pins Qwen3-4B |
 | Demonstrated model-quality lift | Not yet | Reproduced smoke measured zero lift |
 
-## OpenEnv roadmap
+## OpenEnv integration
 
-The current repository is **not OpenEnv-compatible**. A BenchFlow environment
-method named `reset` is not evidence of OpenEnv compatibility. Credible
-compatibility requires an actual OpenEnv client/server surface and an
-end-to-end lifecycle test.
-
-The minimum adapter should provide:
+The supported path is:
 
 ```text
-integrations/openenv/
-  openenv.yaml
-  models.py
-  client.py
-  server/
-    app.py
-    posttrain_environment.py
-  tests/
-    test_lifecycle.py
-    test_task_adapter.py
+TRL
+    -> OpenEnv environment_factory adapter
+    -> OpenEnv client/server protocol
+    -> BenchFlow task, verifier, reward, and artifact engine
+    -> Docker or Daytona
 ```
 
-Acceptance requires all of the following:
+The implementation is intentionally a protocol layer:
 
-1. Start an OpenEnv-compatible server around a checked-in PostTrain task.
+```text
+benchflow_pipeline/openenv/
+  models.py
+  client.py
+  server.py
+  tool_env.py
+```
+
+Real OpenEnv HTTP/WebSocket tests verify:
+
+1. Start an OpenEnv server around the BenchFlow adapter.
 2. Connect with the real OpenEnv client.
 3. Call `reset`, execute one or more `step` actions, and retrieve state.
-4. Terminate or submit the episode and run the existing verifier.
+4. Submit or finalize an unsubmitted episode.
 5. Return reward, completion state, and artifact references through OpenEnv
    models.
 6. Reset again and prove sandbox isolation.
-7. Pass a no-secret Docker lifecycle test in CI.
-8. Document the mapping between one-shot PostTrain trials and long-lived
-   OpenEnv episodes.
+7. Keep concurrent sessions isolated.
+
+A manual Docker parity canary also runs the same checked-in task and verifier
+through the direct and OpenEnv integrations. Both paths produced identical
+oracle output, reward `1.0`, and complete BenchFlow artifact trees. The
+protocol lifecycle tests run in CI; the Docker canary remains an operator test.
+
+Set `runtime.openenv_url` only for a separately deployed copy that shares the
+pipeline's pinned task snapshots and BenchFlow artifact filesystem. When
+omitted, the pipeline starts a local server. A general remote deployment still
+requires task-resolution and artifact-transfer contracts. In both current
+cases, BenchFlow remains the task/runtime/eval engine.
 
 The related upstream discussion is
 [huggingface/OpenEnv#898](https://github.com/huggingface/OpenEnv/issues/898).
-That issue proposes validation support inside OpenEnv; it does not make this
-repository OpenEnv-compatible.
+That issue proposes validation support inside OpenEnv. This repository's
+compatibility comes from the adapter and lifecycle tests above.
 
 ## Documentation precedence
 

--- a/docs/training-pipeline.md
+++ b/docs/training-pipeline.md
@@ -7,7 +7,7 @@ It accepts explicit training and held-out evaluation task lists and produces a
 versioned score report after SFT and optional GRPO.
 
 For the broader system boundaries and compatibility matrix, including the
-current absence of an OpenEnv adapter, see
+implemented OpenEnv adapter boundary, see
 [`architecture-status.md`](architecture-status.md).
 
 ```text
@@ -18,7 +18,7 @@ training task list + held-out eval task list + pinned TOML recipe
     -> convert and validate tool-aware SFT data
     -> train and merge a LoRA SFT checkpoint
     -> evaluate a training-task reward gate
-    -> run GRPO only when the gate passes
+    -> run GRPO according to the configured run policy
     -> evaluate the final model on held-out tasks
     -> write paired lift and score reports
 ```
@@ -28,9 +28,34 @@ BenchFlow owns task snapshots, Daytona or Docker sandboxes, the `run_bash` and
 evaluation. TRL owns SFT and GRPO optimization. The pipeline is Harbor-free and
 does not translate Harbor trajectories.
 
-This is a BenchFlow runtime integration, not an OpenEnv implementation. It does
-not expose an OpenEnv `EnvClient`, served `Environment`, `openenv.yaml`, or HF
-Jobs launcher.
+OpenEnv is an optional protocol adapter in front of the same BenchFlow engine.
+The adapter exposes a real served `Environment` and typed `EnvClient`; it does
+not duplicate BenchFlow task loading, sandboxes, verifiers, rewards, artifacts,
+or held-out evaluation. HF Jobs launch remains out of scope.
+
+`runtime.openenv_url` currently supports only deployments that share the task
+snapshot and BenchFlow artifact filesystem with the pipeline process. A fully
+remote deployment needs a future task-resolution and artifact-transfer protocol.
+
+SFT optimization consumes verified tool-aware rows and does not call the
+environment. Environment interaction occurs during teacher collection,
+evaluation, the reward gate, and GRPO rollouts.
+
+```mermaid
+flowchart LR
+    Input["PostTrain task packages + pinned recipe"] --> Pipeline["PostTrain pipeline"]
+    Pipeline --> TRL["TRL SFT + GRPO"]
+    TRL --> Backend{"Environment integration"}
+    Backend --> Direct["Direct BenchFlow"]
+    Backend --> OE["OpenEnv protocol"]
+    OE --> BF["BenchFlow task + verifier"]
+    Direct --> BF
+    BF --> Runtime["Docker / Daytona"]
+    Runtime --> BF
+    BF --> TRL
+    TRL --> Eval["Held-out BenchFlow evaluation"]
+    Eval --> Output["score.json + paired lift artifacts"]
+```
 
 ## Public contract
 
@@ -106,10 +131,10 @@ Dry-run records the full possible path, including conditional GRPO. Therefore
 | `[model]` | Base model ID and immutable model revision |
 | `[train_dataset]` | HF task repository, revision, path, and training task-list file |
 | `[eval_dataset]` | Separate HF repository/revision and held-out task-list file |
-| `[runtime]` | Daytona or Docker sandbox, tool limits, generation counts, and vLLM toggle |
+| `[runtime]` | Direct/OpenEnv integration, Daytona/Docker sandbox, tool limits, generation counts, and vLLM toggle |
 | `[teacher]` | Teacher model, credential variable names, attempts, and required verified rows |
 | `[sft]` | Enable flag, optimizer settings, sequence length, and LoRA dimensions |
-| `[grpo]` | Enable flag, training-task gate threshold/count, optimizer settings, and steps |
+| `[grpo]` | Enable flag, run policy, training-task gate threshold/count, optimizer settings, and steps |
 | `[tracking]` | W&B or disabled reporting |
 | `[output]` | Run root relative to the recipe |
 
@@ -169,8 +194,10 @@ GRPO then starts from the pinned base model. It still gates on training tasks;
 the held-out eval set is never used to decide whether to train. Set
 `[grpo].enabled = false` for SFT-only runs.
 
-GRPO runs only when reward on the first `[grpo].gate_task_count` training tasks
-is at least `[grpo].threshold`. A skipped GRPO stage is a valid result. Larger
+By default, GRPO runs only when reward on the first `[grpo].gate_task_count`
+training tasks is at least `[grpo].threshold`. `run_policy = "always"` forces
+the stage even at zero reward to validate plumbing; it is not a learning
+recommendation. A skipped GRPO stage is a valid result. Larger
 experiments should use separate training, development/gate, and final held-out
 lists.
 

--- a/pipelines/benchflow-task-posttrain/README.md
+++ b/pipelines/benchflow-task-posttrain/README.md
@@ -1,12 +1,13 @@
 # BenchFlow Task-List Post-Training Pipeline
 
-This is the public, reproducible training path for running SFT and conditional
-GRPO over BenchFlow-compatible task suites.
+This is the public, reproducible training path for running SFT and optional
+GRPO over BenchFlow-compatible task suites. TRL can drive BenchFlow directly
+or through a real OpenEnv client/server protocol adapter.
 
 The repository-wide architecture and compatibility status is documented in
 [`docs/architecture-status.md`](../../docs/architecture-status.md). In
-particular, this package does not currently provide OpenEnv compatibility or an
-HF Jobs execution path.
+particular, this package provides OpenEnv protocol compatibility; HF Jobs
+execution remains outside the current implementation.
 
 The interface is intentionally small:
 
@@ -22,7 +23,11 @@ training task list + held-out eval task list + TOML recipe
 
 BenchFlow owns task snapshots, sandbox lifecycle, tools, verifiers, rollout
 artifacts, and paired evaluation. TRL owns SFT and GRPO optimization. The
-pipeline does not depend on Harbor and does not translate Harbor trajectories.
+OpenEnv is an optional protocol between them, not a second runtime or eval
+engine. The pipeline does not depend on Harbor or translate Harbor trajectories.
+The optional `openenv_url` mode currently requires a shared filesystem for
+pinned task snapshots and BenchFlow artifacts; it is not a general remote
+artifact transport.
 
 ## Repository Layout
 
@@ -36,6 +41,7 @@ benchflow-task-posttrain/
   src/.../teacher.py       verified run_bash/submit demonstrations
   src/.../sft.py           tool-aware LoRA SFT and weight merge
   src/.../policy.py        BenchFlow-backed eval and GRPO
+  src/.../openenv/         OpenEnv client/server protocol adapter
   tests/                   no-spend contract tests
 ```
 
@@ -71,6 +77,11 @@ posttrainarena-train run \
 For a GPU host, `scripts/bootstrap_gpu.sh` installs this package and its pinned
 BenchFlow dependency into an isolated virtual environment.
 
+Use `configs/qwen3-4b-data-agent-openenv-smoke.toml` to route environment
+interaction through OpenEnv. It sets `grpo.run_policy = "always"` so a
+zero-reward GRPO run can validate plumbing; production recipes should normally
+retain `run_policy = "on_reward"`.
+
 ## Credentials
 
 Load credentials from a secret manager or an untracked environment file. Do
@@ -79,7 +90,7 @@ not place them in TOML recipes, task lists, command-line arguments, or commits.
 The example recipe requires:
 
 - `HF_TOKEN` for task snapshots and optional artifact publication
-- `DAYTONA_API_KEY` for `runtime.environment = "daytona"`
+- `DAYTONA_API_KEY` for `runtime.sandbox = "daytona"`
 - `GLM_API_KEY` and `GLM_BASE_URL` for the example teacher
 - `WANDB_API_KEY` when `tracking.report_to = "wandb"`
 - any verifier-specific credentials required by the selected task packages
@@ -106,8 +117,8 @@ runs/<run-name>/reports/score.json
 
 Important fields include `baseline_score`, `sft_score`, `grpo_gate_score`,
 `score_after_posttrain`, `delta_score`, `grpo_planned`, `grpo_ran`, exact task
-IDs, dataset revisions, BenchFlow commit, and the recorded stage commands. A
-dry-run may set `grpo_planned` while leaving `grpo_ran` false.
+IDs, dataset revisions, BenchFlow commit, `grpo_run_policy`, and the recorded
+stage commands. A dry-run may set `grpo_planned` while leaving `grpo_ran` false.
 
 ## Reward Gate
 
@@ -115,6 +126,9 @@ GRPO runs only when the post-SFT score on the configured training-task gate is
 at least `grpo.threshold`. This prevents spending GPU time on a constant-zero
 reward distribution. A skipped GRPO stage is a valid pipeline result, not a
 runtime failure.
+
+`grpo.run_policy = "always"` bypasses the reward decision for end-to-end
+plumbing validation. It is not a recommendation for useful RL training.
 
 Do not use held-out eval tasks to tune this gate. Production recipes should use
 separate training, gate/development, and final evaluation lists.
@@ -144,9 +158,15 @@ Before opening a PR:
 ```bash
 python3 -m pytest pipelines/benchflow-task-posttrain/tests -q
 python3 -m py_compile \
-  pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/*.py
+  pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/*.py \
+  pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/openenv/*.py
 ```
 
 New recipes should pin dataset revisions and model revisions, use new task-list
 files, document expected compute, and default to no-spend tests. Never commit
 checkpoints, trajectories, raw provider responses, or credentials.
+
+The CI protocol tests use OpenEnv's real HTTP/WebSocket transport with a fake
+BenchFlow boundary. Before changing runtime semantics, also run a real Docker
+parity canary against one checked-in task and compare reward plus artifact
+trees across `integration = "benchflow"` and `integration = "openenv"`.

--- a/pipelines/benchflow-task-posttrain/configs/qwen3-4b-data-agent-openenv-smoke.toml
+++ b/pipelines/benchflow-task-posttrain/configs/qwen3-4b-data-agent-openenv-smoke.toml
@@ -15,8 +15,11 @@ path = "tasks"
 task_list = "../task-lists/data-agent-eval-2.txt"
 
 [runtime]
-integration = "benchflow"
+integration = "openenv"
 sandbox = "daytona"
+# openenv_url is supported only when client and server share the pinned task
+# snapshots and BenchFlow artifact filesystem. When omitted, the pipeline
+# starts a real local OpenEnv server around BenchFlow.
 sandbox_user = "agent"
 bash_timeout_sec = 120
 max_output_chars = 8192
@@ -46,7 +49,8 @@ lora_alpha = 32
 
 [grpo]
 enabled = true
-run_policy = "on_reward"
+# Plumbing mode: run GRPO even when the training-task gate reward is zero.
+run_policy = "always"
 threshold = 0.05
 gate_task_count = 4
 max_steps = 2

--- a/pipelines/benchflow-task-posttrain/pyproject.toml
+++ b/pipelines/benchflow-task-posttrain/pyproject.toml
@@ -20,11 +20,16 @@ Documentation = "https://github.com/benchflow-ai/posttrainarena/blob/main/docs/t
 [project.optional-dependencies]
 train = [
   "benchflow[trl,sandbox-daytona] @ git+https://github.com/benchflow-ai/benchflow.git@0b41232cf02e9c4f22c01e284724dd2a02c3f468",
+  "openenv @ git+https://github.com/huggingface/OpenEnv.git@6823135a714814e3efb3e39c4a9edff01e1a2a98",
   "openai>=2.0",
   "peft>=0.18,<0.19",
   "wandb>=0.25,<0.26",
 ]
-test = ["pytest>=8.0"]
+test = [
+  "benchflow[trl] @ git+https://github.com/benchflow-ai/benchflow.git@0b41232cf02e9c4f22c01e284724dd2a02c3f468",
+  "openenv @ git+https://github.com/huggingface/OpenEnv.git@6823135a714814e3efb3e39c4a9edff01e1a2a98",
+  "pytest>=8.0",
+]
 
 [project.scripts]
 posttrainarena-train = "posttrainarena.benchflow_pipeline.cli:main"

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/config.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/config.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 
 BENCHFLOW_COMMIT = "0b41232cf02e9c4f22c01e284724dd2a02c3f468"
+GrpoRunPolicy = Literal["on_reward", "always"]
 
 
 def _table(data: dict[str, Any], name: str) -> dict[str, Any]:
@@ -33,7 +34,10 @@ class DatasetConfig:
 
 @dataclass(frozen=True)
 class RuntimeConfig:
-    environment: str = "daytona"
+    integration: str = "benchflow"
+    environment: str | None = None
+    sandbox: str | None = None
+    openenv_url: str | None = None
     sandbox_user: str | None = "agent"
     bash_timeout_sec: int = 120
     max_output_chars: int = 8192
@@ -69,6 +73,7 @@ class SftConfig:
 @dataclass(frozen=True)
 class GrpoConfig:
     enabled: bool = True
+    run_policy: GrpoRunPolicy = "on_reward"
     threshold: float = 0.05
     gate_task_count: int = 4
     max_steps: int = 5
@@ -96,10 +101,24 @@ class PipelineConfig:
     tracking: TrackingConfig = field(default_factory=TrackingConfig)
     output_root: Path = Path("runs")
 
+    @property
+    def sandbox(self) -> str:
+        return self.runtime.sandbox or self.runtime.environment or "daytona"
+
     def validate(self) -> None:
         errors: list[str] = []
-        if self.runtime.environment not in {"docker", "daytona"}:
-            errors.append("runtime.environment must be docker or daytona")
+        if self.runtime.integration not in {"benchflow", "openenv"}:
+            errors.append("runtime.integration must be benchflow or openenv")
+        if self.runtime.openenv_url and self.runtime.integration != "openenv":
+            errors.append("runtime.openenv_url requires integration = openenv")
+        if (
+            self.runtime.sandbox is not None
+            and self.runtime.environment is not None
+            and self.runtime.sandbox != self.runtime.environment
+        ):
+            errors.append("runtime.sandbox conflicts with legacy runtime.environment")
+        if self.sandbox not in {"docker", "daytona"}:
+            errors.append("runtime.sandbox must be docker or daytona")
         if self.runtime.num_generations < 2:
             errors.append("runtime.num_generations must be at least 2 for GRPO")
         if self.runtime.max_completion_length < 1:
@@ -108,6 +127,8 @@ class PipelineConfig:
             errors.append("runtime.max_tool_calling_iterations must be positive")
         if not 0 <= self.grpo.threshold <= 1:
             errors.append("grpo.threshold must be between 0 and 1")
+        if self.grpo.run_policy not in {"on_reward", "always"}:
+            errors.append("grpo.run_policy must be on_reward or always")
         if self.grpo.gate_task_count < 1:
             errors.append("grpo.gate_task_count must be positive")
         if self.grpo.max_steps < 1:

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/integrations.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/integrations.py
@@ -1,0 +1,71 @@
+"""Environment integration boundary shared by collection, evaluation, and RL."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .config import PipelineConfig
+
+
+@dataclass(frozen=True)
+class EnvironmentIntegration:
+    """The exact environment-facing contract consumed by this pipeline."""
+
+    train_dataset_rows: tuple[dict[str, Any], ...]
+    environment_factory: Callable[[], Any]
+    reward_funcs: tuple[Callable[..., list[float]], ...]
+    _train_dataset_factory: Callable[[], Any]
+    _close: Callable[[], None] = lambda: None
+
+    @property
+    def train_dataset(self) -> Any:
+        return self._train_dataset_factory()
+
+    def trainer_kwargs(self) -> dict[str, Any]:
+        return {
+            "train_dataset": self.train_dataset,
+            "environment_factory": self.environment_factory,
+            "reward_funcs": list(self.reward_funcs),
+        }
+
+    def close(self) -> None:
+        self._close()
+
+
+def build_environment_integration(
+    *,
+    config: PipelineConfig,
+    tasks_dir: Path,
+    task_ids: list[str],
+    jobs_dir: Path,
+    reset_message: str,
+) -> EnvironmentIntegration:
+    """Build either transport around one canonical BenchFlow specification."""
+
+    from benchflow.integrations.trl import BashHarnessConfig, BenchFlowSpec
+
+    spec = BenchFlowSpec(
+        tasks_dir=tasks_dir,
+        include_tasks=task_ids,
+        bash_harness=BashHarnessConfig(
+            environment=config.sandbox,
+            sandbox_user=config.runtime.sandbox_user,
+            jobs_dir=jobs_dir,
+            reset_message=reset_message,
+            bash_timeout_sec=config.runtime.bash_timeout_sec,
+            max_output_chars=config.runtime.max_output_chars,
+        ),
+    )
+    if config.runtime.integration == "openenv":
+        from .openenv import build_openenv_integration
+
+        return build_openenv_integration(spec, config.runtime.openenv_url)
+    return EnvironmentIntegration(
+        train_dataset_rows=spec.train_dataset_rows,
+        environment_factory=spec.environment_factory,
+        reward_funcs=tuple(spec.reward_funcs),
+        _train_dataset_factory=lambda: spec.train_dataset,
+    )

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/openenv/__init__.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/openenv/__init__.py
@@ -1,0 +1,5 @@
+"""Real OpenEnv protocol adapter around the BenchFlow runtime."""
+
+from .tool_env import build_openenv_integration
+
+__all__ = ["build_openenv_integration"]

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/openenv/client.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/openenv/client.py
@@ -1,0 +1,34 @@
+"""Typed OpenEnv client for the PostTrain protocol."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from openenv.core import EnvClient
+from openenv.core.client_types import StepResult
+
+from .models import PostTrainAction, PostTrainObservation, PostTrainState
+
+
+class PostTrainEnvClient(
+    EnvClient[PostTrainAction, PostTrainObservation, PostTrainState]
+):
+    def _step_payload(self, action: PostTrainAction) -> dict[str, Any]:
+        return action.model_dump()
+
+    def _parse_result(
+        self, payload: dict[str, Any]
+    ) -> StepResult[PostTrainObservation]:
+        observation_payload = dict(payload["observation"])
+        observation_payload["reward"] = payload.get("reward")
+        observation_payload["done"] = payload.get("done", False)
+        observation = PostTrainObservation.model_validate(observation_payload)
+        return StepResult(
+            observation=observation,
+            reward=payload.get("reward"),
+            done=payload.get("done", False),
+            metadata=payload.get("metadata"),
+        )
+
+    def _parse_state(self, payload: dict[str, Any]) -> PostTrainState:
+        return PostTrainState.model_validate(payload)

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/openenv/models.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/openenv/models.py
@@ -1,0 +1,27 @@
+"""Wire models for the PostTrain OpenEnv protocol."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from openenv.core.env_server.types import Action, Observation, State
+
+
+class PostTrainAction(Action):
+    type: Literal["run_bash", "submit", "finalize"]
+    command: str | None = None
+    answer: str | None = None
+
+
+class PostTrainObservation(Observation):
+    output: str = ""
+    task_id: str | None = None
+    rollout_dir: str | None = None
+    last_returncode: int | None = None
+
+
+class PostTrainState(State):
+    task_id: str | None = None
+    done: bool = False
+    reward: float = 0.0
+    rollout_dir: str | None = None

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/openenv/server.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/openenv/server.py
@@ -1,0 +1,164 @@
+"""OpenEnv server that delegates every episode to BenchFlow."""
+
+from __future__ import annotations
+
+import atexit
+import socket
+import threading
+import time
+from collections.abc import Callable
+from typing import Any
+from urllib.request import urlopen
+
+from openenv.core.env_server.http_server import create_app
+from openenv.core.env_server.interfaces import Environment
+
+from .models import PostTrainAction, PostTrainObservation, PostTrainState
+
+
+class BenchFlowOpenEnv(Environment):
+    """Protocol surface over one owned BenchFlow runtime environment."""
+
+    SUPPORTS_CONCURRENT_SESSIONS = True
+
+    def __init__(self, environment_factory: Callable[[], Any]) -> None:
+        super().__init__()
+        self._environment = environment_factory()
+        self._episode_id: str | None = None
+        self._step_count = 0
+        self._done = False
+
+    def reset(
+        self,
+        seed: int | None = None,
+        episode_id: str | None = None,
+        **kwargs: Any,
+    ) -> PostTrainObservation:
+        del seed
+        output = self._environment.reset(**kwargs) or ""
+        self._episode_id = episode_id
+        self._step_count = 0
+        self._done = False
+        return self._observation(str(output))
+
+    def step(
+        self,
+        action: PostTrainAction,
+        timeout_s: float | None = None,
+        **kwargs: Any,
+    ) -> PostTrainObservation:
+        del timeout_s, kwargs
+        if self._done:
+            raise RuntimeError("episode is already complete")
+        self._step_count += 1
+        if action.type == "run_bash":
+            if action.command is None:
+                raise ValueError("run_bash requires command")
+            return self._observation(self._environment.run_bash(action.command))
+        if action.type == "submit":
+            if action.answer is None:
+                raise ValueError("submit requires answer")
+            output = self._environment.submit(action.answer)
+        else:
+            self._environment._finalize()
+            output = "episode finalized"
+        self._done = True
+        return self._observation(output)
+
+    @property
+    def state(self) -> PostTrainState:
+        return PostTrainState(
+            episode_id=self._episode_id,
+            step_count=self._step_count,
+            task_id=self._environment.task_id,
+            done=self._done,
+            reward=float(self._environment.reward),
+            rollout_dir=_path_string(self._environment.rollout_dir),
+        )
+
+    def close(self) -> None:
+        self._environment._close()
+
+    def _observation(self, output: str) -> PostTrainObservation:
+        return PostTrainObservation(
+            output=output,
+            reward=float(self._environment.reward),
+            done=self._done,
+            task_id=self._environment.task_id,
+            rollout_dir=_path_string(self._environment.rollout_dir),
+            last_returncode=self._environment.last_returncode,
+        )
+
+
+def create_openenv_app(environment_factory: Callable[[], Any]):
+    return create_app(
+        lambda: BenchFlowOpenEnv(environment_factory),
+        PostTrainAction,
+        PostTrainObservation,
+        env_name="posttrain-benchflow",
+        max_concurrent_envs=64,
+    )
+
+
+class LocalOpenEnvServer:
+    """Own a real local HTTP/WebSocket OpenEnv server for one integration."""
+
+    def __init__(self, environment_factory: Callable[[], Any]) -> None:
+        self._environment_factory = environment_factory
+        self._server: Any | None = None
+        self._thread: threading.Thread | None = None
+        self._lock = threading.RLock()
+        self._base_url: str | None = None
+        atexit.register(self.close)
+
+    @property
+    def base_url(self) -> str:
+        with self._lock:
+            if self._base_url is None:
+                self._start()
+            assert self._base_url is not None
+            return self._base_url
+
+    def close(self) -> None:
+        with self._lock:
+            server = self._server
+            thread = self._thread
+            self._server = None
+            self._thread = None
+            self._base_url = None
+        if server is not None:
+            server.should_exit = True
+        if thread is not None:
+            thread.join(timeout=5)
+
+    def _start(self) -> None:
+        import uvicorn
+
+        port = _unused_port()
+        app = create_openenv_app(self._environment_factory)
+        config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+        server = uvicorn.Server(config)
+        thread = threading.Thread(target=server.run, daemon=True)
+        self._server = server
+        self._thread = thread
+        self._base_url = f"http://127.0.0.1:{port}"
+        thread.start()
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            try:
+                with urlopen(f"{self._base_url}/health", timeout=0.25):
+                    return
+            except OSError:
+                time.sleep(0.05)
+        self.close()
+        raise RuntimeError("OpenEnv server did not become healthy")
+
+
+def _unused_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _path_string(value: Any) -> str | None:
+    return None if value is None else str(value)

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/openenv/tool_env.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/openenv/tool_env.py
@@ -1,0 +1,128 @@
+"""TRL-compatible tool environment backed by a real OpenEnv client."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from ..integrations import EnvironmentIntegration
+from .client import PostTrainEnvClient
+from .models import PostTrainAction, PostTrainObservation
+from .server import LocalOpenEnvServer
+
+
+class OpenEnvToolEnvironment:
+    """Expose only the model tools while retaining protocol lifecycle control."""
+
+    def __init__(self, base_url: str) -> None:
+        self._client = PostTrainEnvClient(base_url=base_url).sync()
+        self._client.connect()
+        self.task_id: str | None = None
+        self.reward = 0.0
+        self.rollout_dir: Path | None = None
+        self.last_returncode: int | None = None
+        self._done = False
+        self._closed = False
+
+    def reset(self, **kwargs: Any) -> str:
+        result = self._client.reset(**kwargs)
+        self._update(result.observation)
+        self._done = result.done
+        return result.observation.output
+
+    def run_bash(self, command: str) -> str:
+        """Run a bash command in the BenchFlow task sandbox.
+
+        Args:
+            command: Bash command to execute in the task workspace.
+
+        Returns:
+            Combined standard output and standard error from the command.
+        """
+        return self._step(PostTrainAction(type="run_bash", command=command)).output
+
+    def submit(self, answer: str) -> str:
+        """Submit the final answer and run the BenchFlow verifier.
+
+        Args:
+            answer: Final answer to write into the task submission path.
+
+        Returns:
+            Confirmation text containing the verifier reward.
+        """
+        return self._step(PostTrainAction(type="submit", answer=answer)).output
+
+    def _finalize(self) -> None:
+        if not self._done:
+            self._step(PostTrainAction(type="finalize"))
+
+    def _close(self) -> None:
+        if not self._closed:
+            self._client.close()
+            self._closed = True
+
+    def _state(self) -> Any:
+        return self._client.state()
+
+    def _step(self, action: PostTrainAction) -> PostTrainObservation:
+        result = self._client.step(action)
+        self._update(result.observation)
+        self._done = result.done
+        return result.observation
+
+    def _update(self, observation: PostTrainObservation) -> None:
+        self.task_id = observation.task_id
+        self.reward = float(observation.reward or 0.0)
+        self.rollout_dir = (
+            Path(observation.rollout_dir) if observation.rollout_dir else None
+        )
+        self.last_returncode = observation.last_returncode
+
+
+def openenv_environment_reward(
+    completions: Sequence[Any],
+    *,
+    environments: Sequence[Any] | None = None,
+    **_: Any,
+) -> list[float]:
+    if environments is None:
+        return [0.0 for _ in completions]
+    rewards: list[float] = []
+    for index, _completion in enumerate(completions):
+        environment = environments[index] if index < len(environments) else None
+        if isinstance(environment, OpenEnvToolEnvironment):
+            environment._finalize()
+        value = getattr(environment, "reward", 0.0)
+        rewards.append(
+            float(value)
+            if isinstance(value, int | float) and not isinstance(value, bool)
+            else 0.0
+        )
+    return rewards
+
+
+def build_openenv_integration(spec: Any, base_url: str | None) -> EnvironmentIntegration:
+    local_server = None if base_url else LocalOpenEnvServer(spec.environment_factory)
+    environments: list[OpenEnvToolEnvironment] = []
+
+    def environment_factory() -> OpenEnvToolEnvironment:
+        resolved_url = base_url or local_server.base_url
+        environment = OpenEnvToolEnvironment(resolved_url)
+        environments.append(environment)
+        return environment
+
+    def close() -> None:
+        for environment in environments:
+            environment._close()
+        environments.clear()
+        if local_server:
+            local_server.close()
+
+    return EnvironmentIntegration(
+        train_dataset_rows=spec.train_dataset_rows,
+        environment_factory=environment_factory,
+        reward_funcs=(openenv_environment_reward,),
+        _train_dataset_factory=lambda: spec.train_dataset,
+        _close=close,
+    )

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/pipeline.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/pipeline.py
@@ -191,6 +191,8 @@ class Pipeline:
             return False
         if self.dry_run:
             return True
+        if self.config.grpo.run_policy == "always":
+            return True
         return gate_score is not None and gate_score >= self.config.grpo.threshold
 
     def _snapshot(
@@ -397,6 +399,7 @@ class Pipeline:
             "score_after_posttrain": final_score,
             "delta_score": delta,
             "grpo_threshold": self.config.grpo.threshold,
+            "grpo_run_policy": self.config.grpo.run_policy,
             "grpo_planned": grpo_planned,
             "grpo_ran": grpo_ran,
             "benchflow_commit": BENCHFLOW_COMMIT,

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/policy.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/policy.py
@@ -7,27 +7,14 @@ from pathlib import Path
 from typing import Any
 
 from .config import PipelineConfig
+from .integrations import build_environment_integration
 from .io import supported_kwargs, write_json
 
 
-def _spec(config: PipelineConfig, tasks_dir: Path, task_ids: list[str], jobs_dir: Path):
-    from benchflow.integrations.trl import BashHarnessConfig, BenchFlowSpec
-
-    return BenchFlowSpec(
-        tasks_dir=tasks_dir,
-        include_tasks=task_ids,
-        bash_harness=BashHarnessConfig(
-            environment=config.runtime.environment,
-            sandbox_user=config.runtime.sandbox_user,
-            jobs_dir=jobs_dir,
-            reset_message=(
-                "Use run_bash to inspect and solve the task. "
-                "Call submit with only the final answer."
-            ),
-            bash_timeout_sec=config.runtime.bash_timeout_sec,
-            max_output_chars=config.runtime.max_output_chars,
-        ),
-    )
+RESET_MESSAGE = (
+    "Use run_bash to inspect and solve the task. "
+    "Call submit with only the final answer."
+)
 
 
 def _common(config: PipelineConfig, output_dir: Path, run_name: str) -> dict[str, Any]:
@@ -69,32 +56,51 @@ def evaluate(
 ) -> dict[str, Any]:
     from trl import GRPOConfig, GRPOTrainer
 
-    spec = _spec(config, tasks_dir, task_ids, jobs_dir)
-    rows = list(spec.train_dataset_rows)
-    eval_batch_size = len(rows)
-    generation_batch_size = math.lcm(eval_batch_size, config.runtime.num_generations)
-    values = {
-        **_common(config, output_dir, run_name),
-        "do_eval": True,
-        "per_device_train_batch_size": config.runtime.num_generations,
-        "per_device_eval_batch_size": eval_batch_size,
-        "generation_batch_size": generation_batch_size,
-        "num_generations": config.runtime.num_generations,
-        "num_generations_eval": 1,
-    }
-    model_init_kwargs = _model_init_kwargs(config, model)
-    if model_init_kwargs:
-        values["model_init_kwargs"] = model_init_kwargs
-    trainer = GRPOTrainer(
-        model=model,
-        args=GRPOConfig(**supported_kwargs(GRPOConfig, values)),
-        train_dataset=spec.train_dataset.select(range(1)),
-        eval_dataset=spec.train_dataset,
-        environment_factory=spec.environment_factory,
-        reward_funcs=spec.reward_funcs,
+    integration = build_environment_integration(
+        config=config,
+        tasks_dir=tasks_dir,
+        task_ids=task_ids,
+        jobs_dir=jobs_dir,
+        reset_message=RESET_MESSAGE,
     )
-    metrics = trainer.evaluate()
-    score = metrics.get("eval_rewards/benchflow_environment_reward/mean")
+    rows = list(integration.train_dataset_rows)
+    try:
+        dataset = integration.train_dataset
+        eval_batch_size = len(rows)
+        generation_batch_size = math.lcm(
+            eval_batch_size, config.runtime.num_generations
+        )
+        values = {
+            **_common(config, output_dir, run_name),
+            "do_eval": True,
+            "per_device_train_batch_size": config.runtime.num_generations,
+            "per_device_eval_batch_size": eval_batch_size,
+            "generation_batch_size": generation_batch_size,
+            "num_generations": config.runtime.num_generations,
+            "num_generations_eval": 1,
+        }
+        model_init_kwargs = _model_init_kwargs(config, model)
+        if model_init_kwargs:
+            values["model_init_kwargs"] = model_init_kwargs
+        trainer = GRPOTrainer(
+            model=model,
+            args=GRPOConfig(**supported_kwargs(GRPOConfig, values)),
+            train_dataset=dataset.select(range(1)),
+            eval_dataset=dataset,
+            environment_factory=integration.environment_factory,
+            reward_funcs=list(integration.reward_funcs),
+        )
+        metrics = trainer.evaluate()
+    finally:
+        integration.close()
+    score = next(
+        (
+            value
+            for key, value in metrics.items()
+            if key.startswith("eval_rewards/") and key.endswith("/mean")
+        ),
+        None,
+    )
     if not isinstance(score, int | float):
         score = metrics.get("eval_reward")
     if not isinstance(score, int | float):
@@ -124,36 +130,47 @@ def train_grpo(
 ) -> dict[str, Any]:
     from trl import GRPOConfig, GRPOTrainer
 
-    spec = _spec(config, tasks_dir, task_ids, jobs_dir)
-    values = {
-        **_common(config, output_dir, run_name),
-        "per_device_train_batch_size": 1,
-        "gradient_accumulation_steps": config.grpo.gradient_accumulation_steps,
-        "generation_batch_size": config.runtime.num_generations,
-        "learning_rate": config.grpo.learning_rate,
-        "max_steps": config.grpo.max_steps,
-        "save_steps": max(1, config.grpo.max_steps),
-        "num_generations": config.runtime.num_generations,
-    }
-    model_init_kwargs = _model_init_kwargs(config, model)
-    if model_init_kwargs:
-        values["model_init_kwargs"] = model_init_kwargs
-    trainer = GRPOTrainer(
-        model=model,
-        args=GRPOConfig(**supported_kwargs(GRPOConfig, values)),
-        **spec.trainer_kwargs(),
+    integration = build_environment_integration(
+        config=config,
+        tasks_dir=tasks_dir,
+        task_ids=task_ids,
+        jobs_dir=jobs_dir,
+        reset_message=RESET_MESSAGE,
     )
-    result = trainer.train()
-    trainer.save_model(str(output_dir))
-    processing_class = getattr(trainer, "processing_class", None)
-    if processing_class is not None:
-        processing_class.save_pretrained(str(output_dir))
-    payload = {
-        "mode": "grpo",
-        "model": model,
-        "task_ids": [row["benchflow_task_id"] for row in spec.train_dataset_rows],
-        "metrics": result.metrics,
-        "jobs_dir": str(jobs_dir),
-    }
-    write_json(output_dir / "train_metrics.json", payload)
-    return payload
+    try:
+        values = {
+            **_common(config, output_dir, run_name),
+            "per_device_train_batch_size": 1,
+            "gradient_accumulation_steps": config.grpo.gradient_accumulation_steps,
+            "generation_batch_size": config.runtime.num_generations,
+            "learning_rate": config.grpo.learning_rate,
+            "max_steps": config.grpo.max_steps,
+            "save_steps": max(1, config.grpo.max_steps),
+            "num_generations": config.runtime.num_generations,
+        }
+        model_init_kwargs = _model_init_kwargs(config, model)
+        if model_init_kwargs:
+            values["model_init_kwargs"] = model_init_kwargs
+        trainer = GRPOTrainer(
+            model=model,
+            args=GRPOConfig(**supported_kwargs(GRPOConfig, values)),
+            **integration.trainer_kwargs(),
+        )
+        result = trainer.train()
+        trainer.save_model(str(output_dir))
+        processing_class = getattr(trainer, "processing_class", None)
+        if processing_class is not None:
+            processing_class.save_pretrained(str(output_dir))
+        payload = {
+            "mode": "grpo",
+            "model": model,
+            "task_ids": [
+                row["benchflow_task_id"] for row in integration.train_dataset_rows
+            ],
+            "metrics": result.metrics,
+            "jobs_dir": str(jobs_dir),
+        }
+        write_json(output_dir / "train_metrics.json", payload)
+        return payload
+    finally:
+        integration.close()

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/teacher.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/teacher.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from .config import PipelineConfig
+from .integrations import build_environment_integration
 from .io import write_json
 
 
@@ -88,11 +89,6 @@ def collect_verified_teacher_rollouts(
     jobs_dir: Path,
     manifest_path: Path,
 ) -> dict[str, Any]:
-    from benchflow.integrations.trl import (
-        BashHarnessConfig,
-        BenchFlowSpec,
-        benchflow_environment_reward,
-    )
     from openai import OpenAI
 
     api_key = os.environ.get(config.teacher.api_key_env)
@@ -103,150 +99,163 @@ def collect_verified_teacher_rollouts(
             f"{config.teacher.api_key_env} and {config.teacher.base_url_env}"
         )
     client = OpenAI(api_key=api_key, base_url=base_url)
-    spec = BenchFlowSpec(
+    integration = build_environment_integration(
+        config=config,
         tasks_dir=tasks_dir,
-        include_tasks=task_ids,
-        bash_harness=BashHarnessConfig(
-            environment=config.runtime.environment,
-            sandbox_user=config.runtime.sandbox_user,
-            jobs_dir=jobs_dir,
-            reset_message=(
-                "Solve the task using run_bash to inspect the workspace. "
-                "Call submit exactly once with only the final answer."
-            ),
-            bash_timeout_sec=config.runtime.bash_timeout_sec,
-            max_output_chars=config.runtime.max_output_chars,
+        task_ids=task_ids,
+        jobs_dir=jobs_dir,
+        reset_message=(
+            "Solve the task using run_bash to inspect the workspace. "
+            "Call submit exactly once with only the final answer."
         ),
     )
-    rows = {row["benchflow_task_id"]: row for row in spec.train_dataset_rows}
-    attempts: list[dict[str, Any]] = []
-    verified: list[dict[str, Any]] = []
-    for task_id in task_ids:
-        for attempt in range(1, config.teacher.max_attempts + 1):
-            env = spec.environment_factory()
-            row = rows[task_id]
-            reset_message = env.reset(**row)
-            if env.rollout_dir is None:
-                raise RuntimeError("BenchFlow did not create a rollout directory")
-            messages = [dict(message) for message in row["prompt"]]
-            if reset_message:
-                messages.append({"role": "user", "content": reset_message})
-            exchanges: list[dict[str, Any]] = []
-            submitted = False
-            error: str | None = None
-            try:
-                for _ in range(config.runtime.max_tool_calling_iterations):
-                    request_messages = [dict(message) for message in messages]
-                    started = time.monotonic()
-                    response = client.chat.completions.create(
-                        model=config.teacher.model,
-                        messages=request_messages,
-                        tools=TOOLS,
-                        tool_choice="auto",
-                        temperature=config.teacher.temperature,
-                        max_tokens=config.teacher.max_tokens,
-                    )
-                    exchanges.append(
-                        _exchange(
+    rows = {
+        row["benchflow_task_id"]: row for row in integration.train_dataset_rows
+    }
+    try:
+        attempts: list[dict[str, Any]] = []
+        verified: list[dict[str, Any]] = []
+        for task_id in task_ids:
+            for attempt in range(1, config.teacher.max_attempts + 1):
+                env = integration.environment_factory()
+                row = rows[task_id]
+                reset_message = env.reset(**row)
+                if env.rollout_dir is None:
+                    raise RuntimeError("BenchFlow did not create a rollout directory")
+                messages = [dict(message) for message in row["prompt"]]
+                if reset_message:
+                    messages.append({"role": "user", "content": reset_message})
+                exchanges: list[dict[str, Any]] = []
+                submitted = False
+                error: str | None = None
+                try:
+                    for _ in range(config.runtime.max_tool_calling_iterations):
+                        request_messages = [dict(message) for message in messages]
+                        started = time.monotonic()
+                        response = client.chat.completions.create(
                             model=config.teacher.model,
-                            request_messages=request_messages,
-                            response=response,
-                            duration_ms=round((time.monotonic() - started) * 1000),
+                            messages=request_messages,
+                            tools=TOOLS,
+                            tool_choice="auto",
+                            temperature=config.teacher.temperature,
+                            max_tokens=config.teacher.max_tokens,
                         )
-                    )
-                    assistant = _as_dict(response.choices[0].message)
-                    assistant.setdefault("role", "assistant")
-                    assistant.setdefault("content", "")
-                    messages.append(assistant)
-                    tool_calls = assistant.get("tool_calls") or []
-                    if not tool_calls:
-                        messages.append(
-                            {
-                                "role": "user",
-                                "content": "Call run_bash to continue, or submit the final answer.",
-                            }
-                        )
-                        continue
-                    for raw_call in tool_calls:
-                        call = _as_dict(raw_call)
-                        function = call.get("function", {})
-                        name = function.get("name")
-                        arguments = function.get("arguments", "{}")
-                        if isinstance(arguments, str):
-                            arguments = json.loads(arguments)
-                        if not isinstance(arguments, dict):
-                            raise ValueError(
-                                f"Arguments for {name!r} must be an object"
-                            )
-                        if name == "run_bash":
-                            output = env.run_bash(str(arguments.get("command", "")))
-                        elif name == "submit":
-                            output = env.submit(str(arguments.get("answer", "")))
-                            submitted = True
-                        else:
-                            output = f"unsupported tool: {name}"
-                        messages.append(
-                            {
-                                "role": "tool",
-                                "tool_call_id": call.get("id"),
-                                "content": output,
-                            }
-                        )
-                        if submitted:
-                            break
-                    if submitted:
                         exchanges.append(
                             _exchange(
                                 model=config.teacher.model,
-                                request_messages=[
-                                    dict(message) for message in messages
-                                ],
-                                response={
-                                    "choices": [
-                                        {
-                                            "message": {
-                                                "role": "assistant",
-                                                "content": "Submission verified by the environment.",
-                                            }
-                                        }
-                                    ]
-                                },
-                                duration_ms=0,
+                                request_messages=request_messages,
+                                response=response,
+                                duration_ms=round(
+                                    (time.monotonic() - started) * 1000
+                                ),
                             )
                         )
-                        break
-            except Exception as exc:
-                error = f"{type(exc).__name__}: {exc}"
-            finally:
-                if not submitted:
-                    benchflow_environment_reward([None], environments=[env])
-                trajectory_path = write_trajectory(env.rollout_dir, exchanges)
-            result = {
-                "task_id": task_id,
-                "attempt": attempt,
-                "reward": float(env.reward),
-                "submitted": submitted,
-                "rollout_dir": str(env.rollout_dir),
-                "trajectory": str(trajectory_path),
-                "exchange_count": len(exchanges),
-                "error": error,
-            }
-            attempts.append(result)
-            print(json.dumps(result, sort_keys=True), flush=True)
-            if result["reward"] == 1.0:
-                verified.append(result)
-                break
-    manifest = {
-        "teacher_model": config.teacher.model,
-        "requested_task_count": len(task_ids),
-        "verified_count": len(verified),
-        "attempts": attempts,
-        "verified": verified,
-    }
-    write_json(manifest_path, manifest)
-    if len(verified) < config.teacher.min_verified:
-        raise RuntimeError(
-            f"Only {len(verified)} verified trajectories; "
-            f"required {config.teacher.min_verified}"
-        )
-    return manifest
+                        assistant = _as_dict(response.choices[0].message)
+                        assistant.setdefault("role", "assistant")
+                        assistant.setdefault("content", "")
+                        messages.append(assistant)
+                        tool_calls = assistant.get("tool_calls") or []
+                        if not tool_calls:
+                            messages.append(
+                                {
+                                    "role": "user",
+                                    "content": (
+                                        "Call run_bash to continue, or submit "
+                                        "the final answer."
+                                    ),
+                                }
+                            )
+                            continue
+                        for raw_call in tool_calls:
+                            call = _as_dict(raw_call)
+                            function = call.get("function", {})
+                            name = function.get("name")
+                            arguments = function.get("arguments", "{}")
+                            if isinstance(arguments, str):
+                                arguments = json.loads(arguments)
+                            if not isinstance(arguments, dict):
+                                raise ValueError(
+                                    f"Arguments for {name!r} must be an object"
+                                )
+                            if name == "run_bash":
+                                output = env.run_bash(
+                                    str(arguments.get("command", ""))
+                                )
+                            elif name == "submit":
+                                output = env.submit(str(arguments.get("answer", "")))
+                                submitted = True
+                            else:
+                                output = f"unsupported tool: {name}"
+                            messages.append(
+                                {
+                                    "role": "tool",
+                                    "tool_call_id": call.get("id"),
+                                    "content": output,
+                                }
+                            )
+                            if submitted:
+                                break
+                        if submitted:
+                            exchanges.append(
+                                _exchange(
+                                    model=config.teacher.model,
+                                    request_messages=[
+                                        dict(message) for message in messages
+                                    ],
+                                    response={
+                                        "choices": [
+                                            {
+                                                "message": {
+                                                    "role": "assistant",
+                                                    "content": (
+                                                        "Submission verified by "
+                                                        "the environment."
+                                                    ),
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    duration_ms=0,
+                                )
+                            )
+                            break
+                except Exception as exc:
+                    error = f"{type(exc).__name__}: {exc}"
+                finally:
+                    if not submitted:
+                        integration.reward_funcs[0]([None], environments=[env])
+                    trajectory_path = write_trajectory(env.rollout_dir, exchanges)
+                    close = getattr(env, "_close", None)
+                    if callable(close):
+                        close()
+                result = {
+                    "task_id": task_id,
+                    "attempt": attempt,
+                    "reward": float(env.reward),
+                    "submitted": submitted,
+                    "rollout_dir": str(env.rollout_dir),
+                    "trajectory": str(trajectory_path),
+                    "exchange_count": len(exchanges),
+                    "error": error,
+                }
+                attempts.append(result)
+                print(json.dumps(result, sort_keys=True), flush=True)
+                if result["reward"] == 1.0:
+                    verified.append(result)
+                    break
+        manifest = {
+            "teacher_model": config.teacher.model,
+            "requested_task_count": len(task_ids),
+            "verified_count": len(verified),
+            "attempts": attempts,
+            "verified": verified,
+        }
+        write_json(manifest_path, manifest)
+        if len(verified) < config.teacher.min_verified:
+            raise RuntimeError(
+                f"Only {len(verified)} verified trajectories; "
+                f"required {config.teacher.min_verified}"
+            )
+        return manifest
+    finally:
+        integration.close()

--- a/pipelines/benchflow-task-posttrain/tests/openenv/test_protocol.py
+++ b/pipelines/benchflow-task-posttrain/tests/openenv/test_protocol.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from transformers.utils import get_json_schema
+
+from posttrainarena.benchflow_pipeline.config import load_config
+from posttrainarena.benchflow_pipeline.integrations import (
+    build_environment_integration,
+)
+from posttrainarena.benchflow_pipeline.openenv.server import LocalOpenEnvServer
+from posttrainarena.benchflow_pipeline.openenv.tool_env import (
+    OpenEnvToolEnvironment,
+    openenv_environment_reward,
+)
+
+
+ROOT = Path(__file__).resolve().parents[4]
+
+
+class FakeBenchFlowEnvironment:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.task_id: str | None = None
+        self.reward = 0.0
+        self.rollout_dir: Path | None = None
+        self.last_returncode: int | None = None
+        self.finalize_count = 0
+        self.closed = False
+
+    def reset(self, **kwargs: Any) -> str:
+        self.task_id = str(kwargs["benchflow_task_id"])
+        self.rollout_dir = self.root / self.task_id / str(id(self))
+        self.rollout_dir.mkdir(parents=True)
+        self.reward = 0.0
+        self.last_returncode = None
+        self.closed = False
+        return f"ready:{self.task_id}"
+
+    def run_bash(self, command: str) -> str:
+        self.last_returncode = 0
+        return f"ran:{command}"
+
+    def submit(self, answer: str) -> str:
+        self.reward = 1.0 if answer == "correct" else 0.0
+        self._finalize()
+        return f"submission recorded; reward={self.reward:g}"
+
+    def _finalize(self) -> None:
+        self.finalize_count += 1
+        self.closed = True
+
+    def _close(self) -> None:
+        self.closed = True
+
+
+def _row(task_id: str) -> dict[str, str]:
+    return {"benchflow_task_id": task_id, "benchflow_task_dir": f"/{task_id}"}
+
+
+def test_public_tools_have_transformers_json_schemas(tmp_path: Path) -> None:
+    server = LocalOpenEnvServer(lambda: FakeBenchFlowEnvironment(tmp_path))
+    environment = OpenEnvToolEnvironment(server.base_url)
+    try:
+        assert get_json_schema(environment.run_bash)["function"]["name"] == "run_bash"
+        assert get_json_schema(environment.submit)["function"]["name"] == "submit"
+    finally:
+        environment._close()
+        server.close()
+
+
+def test_real_benchflow_spec_builds_openenv_tool_factory(tmp_path: Path) -> None:
+    config = load_config(
+        ROOT
+        / "pipelines/benchflow-task-posttrain/configs/qwen3-4b-data-agent-openenv-smoke.toml"
+    )
+    integration = build_environment_integration(
+        config=config,
+        tasks_dir=ROOT / "starting-kit/examples",
+        task_ids=["seclog-bruteforce-triage"],
+        jobs_dir=tmp_path,
+        reset_message="solve",
+    )
+    environment = integration.environment_factory()
+    try:
+        assert integration.train_dataset_rows[0]["benchflow_task_id"] == (
+            "seclog-bruteforce-triage"
+        )
+        assert get_json_schema(environment.run_bash)["function"]["name"] == "run_bash"
+        assert get_json_schema(environment.submit)["function"]["name"] == "submit"
+    finally:
+        integration.close()
+
+
+def test_real_openenv_protocol_preserves_tools_reward_and_artifacts(
+    tmp_path: Path,
+) -> None:
+    environments: list[FakeBenchFlowEnvironment] = []
+
+    def factory() -> FakeBenchFlowEnvironment:
+        environment = FakeBenchFlowEnvironment(tmp_path)
+        environments.append(environment)
+        return environment
+
+    server = LocalOpenEnvServer(factory)
+    environment = OpenEnvToolEnvironment(server.base_url)
+    try:
+        assert environment.reset(**_row("task-a")) == "ready:task-a"
+        assert environment.run_bash("pwd") == "ran:pwd"
+        assert environment.last_returncode == 0
+        state = environment._state()
+        assert state.task_id == "task-a"
+        assert state.step_count == 1
+        assert state.done is False
+        assert environment.submit("correct") == "submission recorded; reward=1"
+        assert environment.reward == 1.0
+        assert environment.rollout_dir is not None
+        assert environment.rollout_dir.is_dir()
+        assert environments[-1].finalize_count == 1
+    finally:
+        environment._close()
+        server.close()
+
+
+def test_reward_function_finalizes_unsubmitted_episode(tmp_path: Path) -> None:
+    environments: list[FakeBenchFlowEnvironment] = []
+
+    def factory() -> FakeBenchFlowEnvironment:
+        environment = FakeBenchFlowEnvironment(tmp_path)
+        environments.append(environment)
+        return environment
+
+    server = LocalOpenEnvServer(factory)
+    environment = OpenEnvToolEnvironment(server.base_url)
+    try:
+        environment.reset(**_row("task-a"))
+        assert openenv_environment_reward([None], environments=[environment]) == [0.0]
+        assert environments[-1].finalize_count == 1
+        assert environments[-1].closed is True
+        assert environment._closed is False
+        assert environment.reset(**_row("task-b")) == "ready:task-b"
+        assert environment.run_bash("pwd") == "ran:pwd"
+    finally:
+        environment._close()
+        server.close()
+
+
+def test_sessions_do_not_share_benchflow_state(tmp_path: Path) -> None:
+    server = LocalOpenEnvServer(lambda: FakeBenchFlowEnvironment(tmp_path))
+    first = OpenEnvToolEnvironment(server.base_url)
+    second = OpenEnvToolEnvironment(server.base_url)
+    try:
+        first.reset(**_row("task-a"))
+        second.reset(**_row("task-b"))
+        first.run_bash("one")
+
+        assert first.task_id == "task-a"
+        assert second.task_id == "task-b"
+        assert first.rollout_dir != second.rollout_dir
+        assert second.last_returncode is None
+    finally:
+        first._close()
+        second._close()
+        server.close()
+
+
+def test_reset_replaces_prior_benchflow_runtime(tmp_path: Path) -> None:
+    environments: list[FakeBenchFlowEnvironment] = []
+
+    def factory() -> FakeBenchFlowEnvironment:
+        environment = FakeBenchFlowEnvironment(tmp_path)
+        environments.append(environment)
+        return environment
+
+    server = LocalOpenEnvServer(factory)
+    environment = OpenEnvToolEnvironment(server.base_url)
+    try:
+        environment.reset(**_row("task-a"))
+        first_rollout = environment.rollout_dir
+        environment.reset(**_row("task-b"))
+
+        assert environment.task_id == "task-b"
+        assert environment.rollout_dir != first_rollout
+        assert environments[-1].task_id == "task-b"
+    finally:
+        environment._close()
+        server.close()

--- a/pipelines/benchflow-task-posttrain/tests/test_config.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -18,6 +19,60 @@ def test_example_config_is_valid_and_pinned() -> None:
     assert len(config.eval_dataset.revision) == 40
     assert config.teacher.min_verified == 15
     assert config.runtime.num_generations == 2
+    assert config.grpo.run_policy == "on_reward"
+
+
+def test_config_accepts_always_grpo_run_policy(tmp_path: Path) -> None:
+    source = ROOT / "configs/qwen3-4b-data-agent-smoke.toml"
+    task_lists = tmp_path / "task-lists"
+    task_lists.mkdir()
+    for name in ("data-agent-train-15.txt", "data-agent-eval-2.txt"):
+        (task_lists / name).write_text((ROOT / "task-lists" / name).read_text())
+    configs = tmp_path / "configs"
+    configs.mkdir()
+    config_path = configs / "always.toml"
+    config_path.write_text(
+        source.read_text().replace(
+            'run_policy = "on_reward"', 'run_policy = "always"'
+        )
+    )
+
+    config = load_config(config_path)
+
+    assert config.grpo.run_policy == "always"
+
+
+def test_config_rejects_unknown_grpo_run_policy() -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    config = replace(config, grpo=replace(config.grpo, run_policy="unconditional"))  # type: ignore[arg-type]
+
+    with pytest.raises(
+        ValueError,
+        match="grpo.run_policy must be on_reward or always",
+    ):
+        config.validate()
+
+
+def test_config_rejects_conflicting_sandbox_aliases() -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    config = replace(
+        config,
+        runtime=replace(config.runtime, environment="docker", sandbox="daytona"),
+    )
+
+    with pytest.raises(ValueError, match="runtime.sandbox conflicts"):
+        config.validate()
+
+
+def test_openenv_url_requires_openenv_integration() -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    config = replace(
+        config,
+        runtime=replace(config.runtime, openenv_url="http://localhost:8000"),
+    )
+
+    with pytest.raises(ValueError, match="openenv_url requires"):
+        config.validate()
 
 
 def test_config_rejects_missing_task_list(tmp_path: Path) -> None:

--- a/pipelines/benchflow-task-posttrain/tests/test_pipeline.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_pipeline.py
@@ -83,3 +83,22 @@ def test_rl_only_dry_run_uses_base_model(tmp_path: Path) -> None:
     )
     assert result["grpo_planned"] is True
     assert result["grpo_ran"] is False
+
+
+def test_grpo_run_policy_can_force_zero_reward_training(tmp_path: Path) -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    gated = Pipeline(
+        replace(config, output_root=tmp_path), run_name="gated", dry_run=False
+    )
+    forced = Pipeline(
+        replace(
+            config,
+            output_root=tmp_path,
+            grpo=replace(config.grpo, run_policy="always"),
+        ),
+        run_name="forced",
+        dry_run=False,
+    )
+
+    assert gated._should_run_grpo(0.0) is False
+    assert forced._should_run_grpo(0.0) is True


### PR DESCRIPTION
## Summary

- add a backend-neutral environment integration boundary for teacher collection, eval, and GRPO
- add a real OpenEnv FastAPI/WebSocket server and typed client that delegate to the existing BenchFlow task/runtime/verifier/artifact engine
- preserve unsubmitted-episode finalization and pooled environment reuse; the integration owns final client/server teardown
- add `runtime.integration`, canonical `runtime.sandbox`, optional shared-filesystem `runtime.openenv_url`, and explicit GRPO `run_policy`
- add an OpenEnv Qwen3-4B smoke recipe with `run_policy = "always"` for zero-reward plumbing validation
- update architecture and operator docs to reflect the implemented ownership boundary and remote limitation

## Architecture

```text
TRL
-> optional OpenEnv environment_factory adapter
-> OpenEnv client/server protocol
-> BenchFlow task, verifier, reward, and artifact engine
-> Docker or Daytona
```

The direct BenchFlow path remains supported. OpenEnv is only the protocol layer; BenchFlow still owns task loading, sandbox lifecycle, verification, rewards, and artifacts.

`openenv_url` currently requires client and server to share pinned task snapshots and the BenchFlow artifact filesystem. General remote task resolution and artifact transfer are not claimed.

## Validation

- clean Python 3.12 virtualenv with pinned BenchFlow/TRL/OpenEnv stack: `21 passed`
- exact Transformers JSON-schema extraction for `run_bash` and `submit`
- pooled lifecycle: `reset -> tools -> reward -> reset -> tools`
- build the adapter through a real `BenchFlowSpec` over a checked-in task
- compile all pipeline and OpenEnv modules
- validate direct and OpenEnv checked-in recipes
- plan and dry-run OpenEnv recipe; assert `integration = openenv`, `run_policy = always`, GRPO planned, GRPO not executed during dry-run
- real OpenEnv HTTP/WebSocket lifecycle tests: reset, step, state, submit, unsubmitted finalize, reset replacement, and concurrent session isolation
- real Docker parity canary on `seclog-bruteforce-triage`: direct and OpenEnv paths produced identical oracle output, reward `1.0`, all 9 verifier checks passed, and both wrote complete BenchFlow artifact trees

## Notes

- no provider or GPU spend is required for CI
- the Docker parity canary is documented as a manual operator validation, not a CI claim
- `run_policy = "always"` is a plumbing/debug mode, not a learning recommendation
