### PR TITLE
Harden GPU training runtime

### DIFF
--- a/pipelines/benchflow-task-posttrain/README.md
+++ b/pipelines/benchflow-task-posttrain/README.md
@@ -75,7 +75,8 @@ posttrainarena-train run \
 ```
 
 For a GPU host, `scripts/bootstrap_gpu.sh` installs this package and its pinned
-BenchFlow dependency into an isolated virtual environment.
+BenchFlow dependency into an isolated virtual environment. The script pins the
+CUDA 12.8 Torch wheel and fails immediately if the GPU is unavailable.
 
 Use `configs/qwen3-4b-data-agent-openenv-smoke.toml` to route environment
 interaction through OpenEnv. It sets `grpo.run_policy = "always"` so a

--- a/pipelines/benchflow-task-posttrain/pyproject.toml
+++ b/pipelines/benchflow-task-posttrain/pyproject.toml
@@ -23,6 +23,7 @@ train = [
   "openenv @ git+https://github.com/huggingface/OpenEnv.git@6823135a714814e3efb3e39c4a9edff01e1a2a98",
   "openai>=2.0",
   "peft>=0.18,<0.19",
+  "torch==2.9.1; sys_platform == 'linux'",
   "wandb>=0.25,<0.26",
 ]
 test = [

--- a/pipelines/benchflow-task-posttrain/scripts/bootstrap_gpu.sh
+++ b/pipelines/benchflow-task-posttrain/scripts/bootstrap_gpu.sh
@@ -19,6 +19,17 @@ git -C "$WORK_ROOT" checkout --detach FETCH_HEAD
 uv venv "$WORK_ROOT/.venv" --python 3.12
 uv pip install --python "$WORK_ROOT/.venv/bin/python" \
   -e "$WORK_ROOT/pipelines/benchflow-task-posttrain[train]"
+uv pip install --python "$WORK_ROOT/.venv/bin/python" \
+  --index https://download.pytorch.org/whl/cu128 \
+  "torch==2.9.1+cu128"
+
+"$WORK_ROOT/.venv/bin/python" - <<'PY'
+import torch
+
+if not torch.cuda.is_available():
+    raise SystemExit(f"CUDA unavailable with torch {torch.__version__}")
+print(f"CUDA ready: {torch.__version__} / {torch.cuda.get_device_name(0)}")
+PY
 
 cat >"$WORK_ROOT/activate-posttrain.sh" <<EOF
 export PATH="$WORK_ROOT/.venv/bin:\$PATH"

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/policy.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/policy.py
@@ -34,11 +34,12 @@ def _common(config: PipelineConfig, output_dir: Path, run_name: str) -> dict[str
     }
 
 
-def _model_init_kwargs(config: PipelineConfig, model: str) -> dict[str, Any] | None:
-    if model != config.model:
-        return None
-    values: dict[str, Any] = {"trust_remote_code": True}
-    if config.model_revision:
+def _model_init_kwargs(config: PipelineConfig, model: str) -> dict[str, Any]:
+    values: dict[str, Any] = {
+        "trust_remote_code": True,
+        "torch_dtype": "bfloat16",
+    }
+    if model == config.model and config.model_revision:
         values["revision"] = config.model_revision
     return values
 
@@ -79,9 +80,7 @@ def evaluate(
             "num_generations": config.runtime.num_generations,
             "num_generations_eval": 1,
         }
-        model_init_kwargs = _model_init_kwargs(config, model)
-        if model_init_kwargs:
-            values["model_init_kwargs"] = model_init_kwargs
+        values["model_init_kwargs"] = _model_init_kwargs(config, model)
         trainer = GRPOTrainer(
             model=model,
             args=GRPOConfig(**supported_kwargs(GRPOConfig, values)),
@@ -145,12 +144,10 @@ def train_grpo(
             "generation_batch_size": config.runtime.num_generations,
             "learning_rate": config.grpo.learning_rate,
             "max_steps": config.grpo.max_steps,
-            "save_steps": max(1, config.grpo.max_steps),
+            "save_strategy": "no",
             "num_generations": config.runtime.num_generations,
         }
-        model_init_kwargs = _model_init_kwargs(config, model)
-        if model_init_kwargs:
-            values["model_init_kwargs"] = model_init_kwargs
+        values["model_init_kwargs"] = _model_init_kwargs(config, model)
         trainer = GRPOTrainer(
             model=model,
             args=GRPOConfig(**supported_kwargs(GRPOConfig, values)),

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/sft.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/sft.py
@@ -55,7 +55,7 @@ def train_sft(
     tokenizer = AutoTokenizer.from_pretrained(config.model, **model_kwargs)
     dataset = Dataset.from_list(render_rows(train_jsonl, tokenizer))
     model = AutoModelForCausalLM.from_pretrained(
-        config.model, torch_dtype="auto", **model_kwargs
+        config.model, torch_dtype="bfloat16", **model_kwargs
     )
     values = {
         "output_dir": str(adapter_dir),
@@ -101,7 +101,7 @@ def train_sft(
     except ImportError:
         pass
     base = AutoModelForCausalLM.from_pretrained(
-        config.model, torch_dtype="auto", **model_kwargs
+        config.model, torch_dtype="bfloat16", **model_kwargs
     )
     merged = PeftModel.from_pretrained(base, str(adapter_dir)).merge_and_unload()
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/pipelines/benchflow-task-posttrain/tests/test_policy.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_policy.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from posttrainarena.benchflow_pipeline.config import load_config
+from posttrainarena.benchflow_pipeline.policy import _model_init_kwargs
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_policy_model_loads_are_bfloat16_and_only_base_is_revision_pinned() -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+
+    base = _model_init_kwargs(config, config.model)
+    merged = _model_init_kwargs(config, "/tmp/sft-merged")
+
+    assert base["torch_dtype"] == "bfloat16"
+    assert base["revision"] == config.model_revision
+    assert merged["torch_dtype"] == "bfloat16"
+    assert "revision" not in merged


### PR DESCRIPTION
## Summary

- pin Linux training installs to Torch 2.9.1 and make GPU bootstrap install the CUDA 12.8 wheel explicitly
- fail GPU bootstrap immediately when CUDA initialization is unavailable
- load base and merged checkpoints in BF16 for policy eval/GRPO and SFT merge
- disable duplicate intermediate GRPO checkpoints because the pipeline already saves the final model and metrics
- add a contract test for BF16 local-checkpoint loading and revision handling

## Real-run evidence

A fresh H100 install of PR #6 resolved unconstrained `torch 2.13.0+cu130`, which could not initialize against Lambda's CUDA 12.8 driver. Installing `torch 2.9.1+cu128` restored CUDA on an NVIDIA H100 80 GB.

The completed OpenEnv 1x1 pipeline also showed that the merged SFT model was 8 GB, while the GRPO model loaded without explicit dtype and saved at 16 GB; the generated step checkpoint duplicated that model and added a 32 GB optimizer state. This patch fixes those production-only issues.

## Validation

- `22 passed` in clean Python 3.12 environment
- pipeline and OpenEnv modules compile
- `git diff --check`
- full OpenEnv pipeline before hardening completed baseline, verified teacher collection, one-step SFT, SFT eval, zero gate, one forced zero-reward GRPO step, final eval, and paired lift without runtime/verifier errors

A post-merge full 1x1 rerun will verify the corrected fresh install and artifact sizes.
