### PR TITLE
Use native data-agent task datasets

### DIFF
--- a/docs/architecture-status.md
+++ b/docs/architecture-status.md
@@ -64,7 +64,7 @@ competition-scale readiness.
 
 | Surface | Status | Evidence or boundary |
 |---|---|---|
-| PostTrain `task.md` packages | Implemented | Starting-kit examples, structural CI, and local Docker harness |
+| PostTrain `task.md` packages | Implemented | Starting-kit examples, structural CI, local Docker harness, and the public 2,238-train/366-eval data-agent datasets |
 | BenchFlow task-list training/eval | Implemented | Public pipeline, tests, CLI dry-run, and completed H100 smoke |
 | Docker runtime | Implemented | Local author harness and BenchFlow runtime option |
 | Daytona runtime | Implemented in pipeline | BenchFlow runtime option; credentials required for real execution |

--- a/docs/training-pipeline.md
+++ b/docs/training-pipeline.md
@@ -28,6 +28,13 @@ BenchFlow owns task snapshots, Daytona or Docker sandboxes, the `run_bash` and
 evaluation. TRL owns SFT and GRPO optimization. The pipeline is Harbor-free and
 does not translate Harbor trajectories.
 
+The default recipes pin the public BenchFlow-native conversions:
+
+- `benchflow/data_agent_rl_environment_train` (`2,238` training tasks)
+- `benchflow/data_agent_rl_environment_eval` (`366` held-out tasks)
+
+Both repositories use `task.md`, `environment/`, and `verifier/` directly.
+
 OpenEnv is an optional protocol adapter in front of the same BenchFlow engine.
 The adapter exposes a real served `Environment` and typed `EnvClient`; it does
 not duplicate BenchFlow task loading, sandboxes, verifiers, rewards, artifacts,

--- a/pipelines/benchflow-task-posttrain/README.md
+++ b/pipelines/benchflow-task-posttrain/README.md
@@ -24,7 +24,10 @@ training task list + held-out eval task list + TOML recipe
 BenchFlow owns task snapshots, sandbox lifecycle, tools, verifiers, rollout
 artifacts, and paired evaluation. TRL owns SFT and GRPO optimization. The
 OpenEnv is an optional protocol between them, not a second runtime or eval
-engine. The pipeline does not depend on Harbor or translate Harbor trajectories.
+engine. The default recipes pin the public BenchFlow-native `task.md` datasets
+`benchflow/data_agent_rl_environment_train` and
+`benchflow/data_agent_rl_environment_eval`. The pipeline does not depend on
+Harbor or translate Harbor trajectories.
 The optional `openenv_url` mode currently requires a shared filesystem for
 pinned task snapshots and BenchFlow artifacts; it is not a general remote
 artifact transport.

--- a/pipelines/benchflow-task-posttrain/configs/qwen3-4b-data-agent-openenv-smoke.toml
+++ b/pipelines/benchflow-task-posttrain/configs/qwen3-4b-data-agent-openenv-smoke.toml
@@ -3,14 +3,14 @@ id = "Qwen/Qwen3-4B"
 revision = "1cfa9a7208912126459214e8b04321603b3df60c"
 
 [train_dataset]
-repo_id = "AdithyaSK/data_agent_rl_environment_train"
-revision = "4073bb9b817aba164d8697cbe504a646522cd07a"
+repo_id = "benchflow/data_agent_rl_environment_train"
+revision = "34ff63c91731df6b3670bfcd7e3d44e6790ddc48"
 path = "tasks"
 task_list = "../task-lists/data-agent-train-15.txt"
 
 [eval_dataset]
-repo_id = "AdithyaSK/data_agent_rl_environment_eval"
-revision = "9240cc381cbadeef82923b64131e174be126c92b"
+repo_id = "benchflow/data_agent_rl_environment_eval"
+revision = "0ea976c79e3248c85737c4f7363484e4d47ce287"
 path = "tasks"
 task_list = "../task-lists/data-agent-eval-2.txt"
 

--- a/pipelines/benchflow-task-posttrain/configs/qwen3-4b-data-agent-smoke.toml
+++ b/pipelines/benchflow-task-posttrain/configs/qwen3-4b-data-agent-smoke.toml
@@ -3,14 +3,14 @@ id = "Qwen/Qwen3-4B"
 revision = "1cfa9a7208912126459214e8b04321603b3df60c"
 
 [train_dataset]
-repo_id = "AdithyaSK/data_agent_rl_environment_train"
-revision = "4073bb9b817aba164d8697cbe504a646522cd07a"
+repo_id = "benchflow/data_agent_rl_environment_train"
+revision = "34ff63c91731df6b3670bfcd7e3d44e6790ddc48"
 path = "tasks"
 task_list = "../task-lists/data-agent-train-15.txt"
 
 [eval_dataset]
-repo_id = "AdithyaSK/data_agent_rl_environment_eval"
-revision = "9240cc381cbadeef82923b64131e174be126c92b"
+repo_id = "benchflow/data_agent_rl_environment_eval"
+revision = "0ea976c79e3248c85737c4f7363484e4d47ce287"
 path = "tasks"
 task_list = "../task-lists/data-agent-eval-2.txt"
 

--- a/pipelines/benchflow-task-posttrain/tests/test_config.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_config.py
@@ -15,6 +15,8 @@ def test_example_config_is_valid_and_pinned() -> None:
     config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
 
     assert config.model == "Qwen/Qwen3-4B"
+    assert config.train_dataset.repo_id == "benchflow/data_agent_rl_environment_train"
+    assert config.eval_dataset.repo_id == "benchflow/data_agent_rl_environment_eval"
     assert len(config.train_dataset.revision) == 40
     assert len(config.eval_dataset.revision) == 40
     assert config.teacher.min_verified == 15


### PR DESCRIPTION
## Summary

- switch the direct BenchFlow and OpenEnv smoke recipes to the public BenchFlow-native data-agent datasets
- pin immutable train/eval revisions
- document the 2,238-train/366-held-out native dataset boundary
- keep Harbor out of the runtime and trajectory path

## Dataset pins

- train: `benchflow/data_agent_rl_environment_train@34ff63c91731df6b3670bfcd7e3d44e6790ddc48`
- eval: `benchflow/data_agent_rl_environment_eval@0ea976c79e3248c85737c4f7363484e4d47ce287`

## Validation

- all 15 train and 2 eval smoke task IDs resolve in the new datasets
- `uv run --extra test pytest -q` — 21 passed
- `posttrainarena-train validate` — valid
- `posttrainarena-train plan` emits the new immutable revisions

## Spend

No model, Daytona, or GPU spend.
