### PR TITLE
Enforce BF16 GRPO checkpoints

### DIFF
--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/policy.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/policy.py
@@ -37,7 +37,7 @@ def _common(config: PipelineConfig, output_dir: Path, run_name: str) -> dict[str
 def _model_init_kwargs(config: PipelineConfig, model: str) -> dict[str, Any]:
     values: dict[str, Any] = {
         "trust_remote_code": True,
-        "torch_dtype": "bfloat16",
+        "dtype": "bfloat16",
     }
     if model == config.model and config.model_revision:
         values["revision"] = config.model_revision
@@ -154,6 +154,9 @@ def train_grpo(
             **integration.trainer_kwargs(),
         )
         result = trainer.train()
+        import torch
+
+        trainer.model.to(dtype=torch.bfloat16)
         trainer.save_model(str(output_dir))
         processing_class = getattr(trainer, "processing_class", None)
         if processing_class is not None:

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/sft.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/sft.py
@@ -55,7 +55,7 @@ def train_sft(
     tokenizer = AutoTokenizer.from_pretrained(config.model, **model_kwargs)
     dataset = Dataset.from_list(render_rows(train_jsonl, tokenizer))
     model = AutoModelForCausalLM.from_pretrained(
-        config.model, torch_dtype="bfloat16", **model_kwargs
+        config.model, dtype="bfloat16", **model_kwargs
     )
     values = {
         "output_dir": str(adapter_dir),
@@ -101,7 +101,7 @@ def train_sft(
     except ImportError:
         pass
     base = AutoModelForCausalLM.from_pretrained(
-        config.model, torch_dtype="bfloat16", **model_kwargs
+        config.model, dtype="bfloat16", **model_kwargs
     )
     merged = PeftModel.from_pretrained(base, str(adapter_dir)).merge_and_unload()
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/pipelines/benchflow-task-posttrain/tests/test_policy.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_policy.py
@@ -15,7 +15,7 @@ def test_policy_model_loads_are_bfloat16_and_only_base_is_revision_pinned() -> N
     base = _model_init_kwargs(config, config.model)
     merged = _model_init_kwargs(config, "/tmp/sft-merged")
 
-    assert base["torch_dtype"] == "bfloat16"
+    assert base["dtype"] == "bfloat16"
     assert base["revision"] == config.model_revision
-    assert merged["torch_dtype"] == "bfloat16"
+    assert merged["dtype"] == "bfloat16"
     assert "revision" not in merged


### PR DESCRIPTION
## Summary

- use the Transformers 5 `dtype="bfloat16"` model-load argument for base and local merged checkpoints
- cast the trained GRPO model to BF16 immediately before final serialization
- update the dtype contract test

## Real-run evidence

The post-hardening full OpenEnv rerun completed every stage without errors and removed duplicate trainer checkpoint state, reducing the GRPO output from 60 GB to 15 GB. Safetensor inspection still showed:

- SFT merged model: BF16, 8.0 GB
- GRPO final model: FP32, 16.1 GB

The remote log contained Transformers' explicit warning that `torch_dtype` is deprecated in favor of `dtype`. This patch fixes that final production-only dtype handoff.

## Validation

- `22 passed`
- compile and diff checks pass
- after merge, the completed run will resume from its existing SFT/gate artifacts and rerun the GRPO/final-eval tail; the final safetensor dtype and size will be checked directly
