### PR TITLE
Document native dataset OpenEnv smoke

### DIFF
--- a/docs/architecture-status.md
+++ b/docs/architecture-status.md
@@ -73,6 +73,7 @@ competition-scale readiness.
 | Harbor | Not a dependency | No Harbor adapter or trajectory translation is used |
 | OpenEnv client/server lifecycle | Implemented | Pinned dependency, served adapter, typed client, real lifecycle tests, finalization, state, and session isolation |
 | OpenEnv/BenchFlow Docker parity | Manually validated | Checked-in security task produced identical output and reward `1.0` through both integrations; CI uses a no-spend fake BenchFlow boundary |
+| Native dataset OpenEnv pipeline | End-to-end smoke validated | One train and one held-out native `task.md` package completed snapshot, teacher collection, SFT, forced GRPO, final eval, and artifact publication; see `docs/native-dataset-openenv-smoke.md` |
 | HF Jobs execution | **Not implemented** | No HF Jobs launcher or deployment workflow exists |
 | Final Qwen3-8B competition recipe | Draft | Current reproducible reference pins Qwen3-4B |
 | Demonstrated model-quality lift | Not yet | Reproduced smoke measured zero lift |

--- a/docs/native-dataset-openenv-smoke.md
+++ b/docs/native-dataset-openenv-smoke.md
@@ -1,0 +1,55 @@
+# Native data-agent OpenEnv smoke
+
+On July 10, 2026, PostTrain Arena completed a real one-train/one-held-out
+end-to-end run against the public BenchFlow-native data-agent datasets.
+
+## Pinned inputs
+
+- PostTrain Arena: `fbdd7c2`
+- BenchFlow: `0b41232cf02e9c4f22c01e284724dd2a02c3f468`
+- OpenEnv: `6823135a714814e3efb3e39c4a9edff01e1a2a98`
+- Train dataset:
+  `benchflow/data_agent_rl_environment_train@34ff63c91731df6b3670bfcd7e3d44e6790ddc48`
+- Eval dataset:
+  `benchflow/data_agent_rl_environment_eval@0ea976c79e3248c85737c4f7363484e4d47ce287`
+- Runtime: local OpenEnv server/client adapter over BenchFlow and Daytona
+- Model: `Qwen/Qwen3-4B`
+
+## Completed stages
+
+The single pipeline invocation completed:
+
+1. native train and eval snapshots;
+2. OpenEnv baseline held-out evaluation;
+3. reward-`1.0` teacher trajectory collection;
+4. tool-aware SFT conversion and validation;
+5. one-step LoRA SFT and BF16 weight merge;
+6. post-SFT held-out and training-gate evaluation;
+7. one forced GRPO step with two rollouts;
+8. BF16 GRPO checkpoint save;
+9. final held-out evaluation and paired lift report.
+
+All seven scored rollout artifacts were healthy, with no infrastructure or
+verifier errors. Scores remained `0.0 -> 0.0`; this validates the system path,
+not model-quality lift.
+
+## Artifacts
+
+- Trajectories:
+  `benchflow/env0-experiment-trajectories@ba11080731be1f15b17962cbb789972795164ebc`
+- SFT checkpoint PR: `benchflow/benchflow-qwen3-4b` discussion `#4`
+- GRPO checkpoint PR: `benchflow/benchflow-qwen3-4b` discussion `#5`
+- W&B run:
+  `benchflow-ai/posttrainarena-native-dataset-e2e/cf7o84cb`
+
+The checkpoint PRs remain open and unmerged.
+
+## Cleanup
+
+Every Daytona sandbox ID referenced by the run was absent during teardown. The
+remote secret file was removed, and the dedicated Lambda H100 instance was
+confirmed terminated.
+
+The run emitted the known non-fatal asynchronous Daytona cleanup warning after
+score artifacts were written. No run sandbox remained active.
+

--- a/docs/training-pipeline.md
+++ b/docs/training-pipeline.md
@@ -35,6 +35,11 @@ The default recipes pin the public BenchFlow-native conversions:
 
 Both repositories use `task.md`, `environment/`, and `verifier/` directly.
 
+A real one-train/one-held-out OpenEnv run completed the full snapshot, teacher,
+SFT, forced-GRPO, final-eval, and publication path on these revisions. See
+[`native-dataset-openenv-smoke.md`](native-dataset-openenv-smoke.md) for the
+exact evidence and claim boundary.
+
 OpenEnv is an optional protocol adapter in front of the same BenchFlow engine.
 The adapter exposes a real served `Environment` and typed `EnvClient`; it does
 not duplicate BenchFlow task loading, sandboxes, verifiers, rewards, artifacts,


### PR DESCRIPTION
## Summary

Document the completed real OpenEnv end-to-end smoke against the public native data-agent train/eval revisions.

## Evidence

- native snapshot -> baseline -> verified teacher -> SFT -> gate -> forced GRPO -> final eval -> publication
- 7 healthy scored rollouts and no infrastructure/verifier errors
- BF16 SFT and GRPO checkpoints in open HF PRs #4 and #5
- trajectories at commit `ba11080731be1f15b17962cbb789972795164ebc`
- score remained 0.0 -> 0.0, so this is a systems claim only
- Daytona run sandboxes absent and dedicated H100 terminated
