### PR TITLE
[codex] Pin BenchFlow pipeline to latest main

### DIFF
--- a/pipelines/benchflow-task-posttrain/pyproject.toml
+++ b/pipelines/benchflow-task-posttrain/pyproject.toml
@@ -19,7 +19,7 @@ Documentation = "https://github.com/benchflow-ai/posttrainarena/blob/main/docs/t
 
 [project.optional-dependencies]
 train = [
-  "benchflow[trl,sandbox-daytona] @ git+https://github.com/benchflow-ai/benchflow.git@0b41232cf02e9c4f22c01e284724dd2a02c3f468",
+  "benchflow[trl,sandbox-daytona] @ git+https://github.com/benchflow-ai/benchflow.git@6eaa14344bd835a3c2c5c31a31470ef994b24a80",
   "openenv @ git+https://github.com/huggingface/OpenEnv.git@6823135a714814e3efb3e39c4a9edff01e1a2a98",
   "openai>=2.0",
   "peft>=0.18,<0.19",
@@ -31,7 +31,7 @@ hf = [
   "tomli-w>=1.2,<2",
 ]
 test = [
-  "benchflow[trl] @ git+https://github.com/benchflow-ai/benchflow.git@0b41232cf02e9c4f22c01e284724dd2a02c3f468",
+  "benchflow[trl] @ git+https://github.com/benchflow-ai/benchflow.git@6eaa14344bd835a3c2c5c31a31470ef994b24a80",
   "huggingface_hub>=0.36,<2",
   "openenv @ git+https://github.com/huggingface/OpenEnv.git@6823135a714814e3efb3e39c4a9edff01e1a2a98",
   "pytest>=8.0",

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/config.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/config.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 
-BENCHFLOW_COMMIT = "0b41232cf02e9c4f22c01e284724dd2a02c3f468"
+BENCHFLOW_COMMIT = "6eaa14344bd835a3c2c5c31a31470ef994b24a80"
 GrpoRunPolicy = Literal["on_reward", "always"]
 
 


### PR DESCRIPTION
## What changed

- pin the PostTrain Arena training and test extras to BenchFlow commit `6eaa14344bd835a3c2c5c31a31470ef994b24a80`
- record the same commit in generated pipeline plans and score reports

## Why

This updates the executable pipeline from the older July 8 BenchFlow snapshot to the July 11 `main` commit that includes live LLM trajectory streaming and the current OpenCode/Daytona artifact path.

The historical native-dataset smoke report remains unchanged because it should continue to identify the commit used for that completed run.

## Validation

- `pipelines/benchflow-task-posttrain/.venv/bin/python -m pytest pipelines/benchflow-task-posttrain/tests -q` (`36 passed`)
- `git diff --check`
- two real SkillsBench canaries with OpenCode + `glm/glm-5.1` + Daytona:
  - `citation-check` with skills: reward `1.0`
  - `3d-scan-calc` without skills: reward `1.0`
- both canaries produced healthy `acp_trajectory.jsonl`, `llm_trajectory.jsonl`, and `results.jsonl` with `training_ready=true`
