### PR TITLE
Migrate teacher collection to OpenCode

### DIFF
--- a/docs/architecture-status.md
+++ b/docs/architecture-status.md
@@ -31,13 +31,18 @@ The supported executable reference is the Qwen3-4B pipeline under
 PostTrain task lists and pinned HF snapshots
     -> direct BenchFlow or OpenEnv protocol integration
     -> BenchFlow task loading and sandbox lifecycle
-    -> BenchFlow run_bash / submit agent harness
-    -> verifier-approved teacher trajectories
+    -> OpenCode teacher rollouts through BenchFlow
+    -> verifier-approved, training-ready teacher trajectories
     -> TRL LoRA SFT and merged checkpoint
-    -> BenchFlow reward gate on training tasks
-    -> optional TRL GRPO
-    -> held-out BenchFlow evaluation and paired lift report
+    -> legacy TRL environment_factory reward gate and optional GRPO
+    -> legacy TRL environment_factory held-out evaluation and paired lift report
 ```
+
+Teacher collection now uses OpenCode as its agent harness with required provider
+telemetry and BenchFlow artifact-health gates. Evaluation and GRPO still use the
+older TRL-owned `run_bash` / `submit` loop in this migration stage; follow-up
+changes will move those stages to the same OpenCode harness before the legacy
+environment path is removed.
 
 The final machine-readable contract is:
 
@@ -70,6 +75,8 @@ competition-scale readiness.
 | Daytona runtime | Implemented in pipeline | BenchFlow runtime option; credentials required for real execution |
 | TRL SFT | Implemented | Tool-aware LoRA SFT and merged checkpoint path |
 | TRL GRPO | Implemented | Reward-gated by default; explicit `always` policy supports zero-reward plumbing runs |
+| OpenCode teacher collection | Implemented | Provider-qualified teacher model, required usage tracking, adaptive retries, and one training-ready rollout selected per task |
+| OpenCode evaluation and GRPO | In migration | Teacher collection is migrated; evaluation and GRPO still use the legacy TRL environment loop |
 | Harbor | Not a dependency | No Harbor adapter or trajectory translation is used |
 | OpenEnv client/server lifecycle | Implemented | Pinned dependency, served adapter, typed client, real lifecycle tests, finalization, state, and session isolation |
 | OpenEnv/BenchFlow Docker parity | Manually validated | Checked-in security task produced identical output and reward `1.0` through both integrations; CI uses a no-spend fake BenchFlow boundary |

--- a/docs/training-pipeline.md
+++ b/docs/training-pipeline.md
@@ -14,7 +14,7 @@ implemented OpenEnv adapter boundary, see
 training task list + held-out eval task list + pinned TOML recipe
     -> snapshot task packages from Hugging Face
     -> evaluate the base model
-    -> collect verifier-approved teacher trajectories
+    -> collect verifier-approved teacher trajectories through OpenCode
     -> convert and validate tool-aware SFT data
     -> train and merge a LoRA SFT checkpoint
     -> evaluate a training-task reward gate
@@ -23,10 +23,11 @@ training task list + held-out eval task list + pinned TOML recipe
     -> write paired lift and score reports
 ```
 
-BenchFlow owns task snapshots, Daytona or Docker sandboxes, the `run_bash` and
-`submit` tools, verifiers, reward extraction, rollout artifacts, and paired
-evaluation. TRL owns SFT and GRPO optimization. The pipeline is Harbor-free and
-does not translate Harbor trajectories.
+BenchFlow owns task snapshots, Daytona or Docker sandboxes, verifiers, reward
+extraction, rollout artifacts, and paired evaluation. OpenCode owns the teacher
+agent loop. TRL owns SFT and GRPO optimization. Evaluation and GRPO still use
+the legacy TRL-owned `run_bash` / `submit` loop during this migration stage.
+The pipeline is Harbor-free and does not translate Harbor trajectories.
 
 The default recipes pin the public BenchFlow-native conversions:
 
@@ -144,7 +145,8 @@ Dry-run records the full possible path, including conditional GRPO. Therefore
 | `[train_dataset]` | HF task repository, revision, path, and training task-list file |
 | `[eval_dataset]` | Separate HF repository/revision and held-out task-list file |
 | `[runtime]` | Direct/OpenEnv integration, Daytona/Docker sandbox, tool limits, generation counts, and vLLM toggle |
-| `[teacher]` | Teacher model, credential variable names, attempts, and required verified rows |
+| `[harness]` | Required OpenCode contract, skill mode, telemetry, concurrency, and setup/idle/wall-clock timeouts; currently applied to teacher collection while evaluation and GRPO migrate in follow-up releases |
+| `[teacher]` | Provider-qualified teacher model, adaptive attempts, reward threshold, post-run token/tool acceptance ceilings, and required verified rows |
 | `[sft]` | Enable flag, optimizer settings, sequence length, and LoRA dimensions |
 | `[grpo]` | Enable flag, run policy, training-task gate threshold/count, optimizer settings, and steps |
 | `[tracking]` | W&B or disabled reporting |
@@ -163,12 +165,11 @@ The example Daytona recipe expects:
 
 - `HF_TOKEN` when private or gated snapshots require it
 - `DAYTONA_API_KEY` for sandbox creation
-- `GLM_API_KEY` and `GLM_BASE_URL` for its OpenAI-compatible teacher
+- `GLM_API_KEY` and `GLM_BASE_URL` for its OpenCode-driven GLM teacher
 - `WANDB_API_KEY` when `tracking.report_to = "wandb"`
 - any task-specific credentials required by selected verifiers
 
-Teacher credential variable names are configurable. Their values are not
-written to the run plan or score report.
+Provider credential values are not written to the run plan or score report.
 
 ## Execute and resume
 

--- a/pipelines/benchflow-task-posttrain/README.md
+++ b/pipelines/benchflow-task-posttrain/README.md
@@ -21,10 +21,12 @@ training task list + held-out eval task list + TOML recipe
     -> held-out score and paired lift report
 ```
 
-BenchFlow owns task snapshots, sandbox lifecycle, tools, verifiers, rollout
-artifacts, and paired evaluation. TRL owns SFT and GRPO optimization. The
-OpenEnv is an optional protocol between them, not a second runtime or eval
-engine. The default recipes pin the public BenchFlow-native `task.md` datasets
+BenchFlow owns task snapshots, sandbox lifecycle, verifiers, rollout artifacts,
+and paired evaluation. OpenCode owns teacher-model interaction. TRL owns SFT
+and GRPO optimization. Evaluation and GRPO remain on the legacy TRL-owned tool
+loop until their follow-up migration changes land. OpenEnv is an optional
+protocol for that legacy path, not a second runtime or eval engine. The default
+recipes pin the public BenchFlow-native `task.md` datasets
 `benchflow/data_agent_rl_environment_train` and
 `benchflow/data_agent_rl_environment_eval`. The pipeline does not depend on
 Harbor or translate Harbor trajectories.
@@ -41,7 +43,7 @@ benchflow-task-posttrain/
   scripts/bootstrap_gpu.sh GPU-host bootstrap
   src/.../config.py        typed TOML contract and validation
   src/.../pipeline.py      resumable stage orchestration
-  src/.../teacher.py       verified run_bash/submit demonstrations
+  src/.../teacher.py       verified OpenCode teacher rollouts
   src/.../sft.py           tool-aware LoRA SFT and weight merge
   src/.../policy.py        BenchFlow-backed eval and GRPO
   src/.../openenv/         OpenEnv client/server protocol adapter
@@ -99,12 +101,11 @@ The example recipe requires:
 
 - `HF_TOKEN` for task snapshots and optional artifact publication
 - `DAYTONA_API_KEY` for `runtime.sandbox = "daytona"`
-- `GLM_API_KEY` and `GLM_BASE_URL` for the example teacher
+- `GLM_API_KEY` and `GLM_BASE_URL` for the example OpenCode teacher model
 - `WANDB_API_KEY` when `tracking.report_to = "wandb"`
 - any verifier-specific credentials required by the selected task packages
 
-Teacher credential variable names are configurable; values are never written
-to the run plan or score report.
+Provider credential values are never written to the run plan or score report.
 
 ## Run
 

--- a/pipelines/benchflow-task-posttrain/configs/qwen3-4b-data-agent-openenv-smoke.toml
+++ b/pipelines/benchflow-task-posttrain/configs/qwen3-4b-data-agent-openenv-smoke.toml
@@ -28,15 +28,23 @@ max_tool_calling_iterations = 25
 num_generations = 2
 use_vllm = false
 
+[harness]
+agent = "opencode"
+skill_mode = "no-skill"
+usage_tracking = "required"
+concurrency = 1
+sandbox_setup_timeout_sec = 300
+agent_idle_timeout_sec = 300
+agent_timeout_sec = 900
+
 [teacher]
 enabled = true
-model = "glm-5.1"
-api_key_env = "GLM_API_KEY"
-base_url_env = "GLM_BASE_URL"
+model = "glm/glm-5.1"
 max_attempts = 3
-max_tokens = 4096
 min_verified = 15
-temperature = 0.2
+min_reward = 1.0
+max_accepted_total_tokens = 200000
+max_accepted_tool_calls = 50
 
 [sft]
 enabled = true

--- a/pipelines/benchflow-task-posttrain/configs/qwen3-4b-data-agent-smoke.toml
+++ b/pipelines/benchflow-task-posttrain/configs/qwen3-4b-data-agent-smoke.toml
@@ -25,15 +25,23 @@ max_tool_calling_iterations = 25
 num_generations = 2
 use_vllm = false
 
+[harness]
+agent = "opencode"
+skill_mode = "no-skill"
+usage_tracking = "required"
+concurrency = 1
+sandbox_setup_timeout_sec = 300
+agent_idle_timeout_sec = 300
+agent_timeout_sec = 900
+
 [teacher]
 enabled = true
-model = "glm-5.1"
-api_key_env = "GLM_API_KEY"
-base_url_env = "GLM_BASE_URL"
+model = "glm/glm-5.1"
 max_attempts = 3
-max_tokens = 4096
 min_verified = 15
-temperature = 0.2
+min_reward = 1.0
+max_accepted_total_tokens = 200000
+max_accepted_tool_calls = 50
 
 [sft]
 enabled = true

--- a/pipelines/benchflow-task-posttrain/configs/qwen3-4b-hf-job-smoke.toml
+++ b/pipelines/benchflow-task-posttrain/configs/qwen3-4b-hf-job-smoke.toml
@@ -25,15 +25,23 @@ max_tool_calling_iterations = 8
 num_generations = 2
 use_vllm = false
 
+[harness]
+agent = "opencode"
+skill_mode = "no-skill"
+usage_tracking = "required"
+concurrency = 1
+sandbox_setup_timeout_sec = 300
+agent_idle_timeout_sec = 300
+agent_timeout_sec = 900
+
 [teacher]
 enabled = true
-model = "glm-5.1"
-api_key_env = "GLM_API_KEY"
-base_url_env = "GLM_BASE_URL"
+model = "glm/glm-5.1"
 max_attempts = 3
-max_tokens = 4096
 min_verified = 1
-temperature = 0.2
+min_reward = 1.0
+max_accepted_total_tokens = 200000
+max_accepted_tool_calls = 50
 
 [sft]
 enabled = true

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/config.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/config.py
@@ -10,9 +10,15 @@ from typing import Any, Literal
 
 BENCHFLOW_COMMIT = "6eaa14344bd835a3c2c5c31a31470ef994b24a80"
 GrpoRunPolicy = Literal["on_reward", "always"]
+HarnessSkillMode = Literal["no-skill", "with-skill"]
+UsageTrackingPolicy = Literal["required"]
 
 
-def _table(data: dict[str, Any], name: str) -> dict[str, Any]:
+def _table(
+    data: dict[str, Any], name: str, *, required: bool = False
+) -> dict[str, Any]:
+    if required and name not in data:
+        raise ValueError(f"Missing required [{name}] table")
     value = data.get(name, {})
     if not isinstance(value, dict):
         raise ValueError(f"[{name}] must be a TOML table")
@@ -22,6 +28,10 @@ def _table(data: dict[str, Any], name: str) -> dict[str, Any]:
 def _resolve(base: Path, value: str | Path) -> Path:
     path = Path(value).expanduser()
     return path if path.is_absolute() else (base / path).resolve()
+
+
+def _is_positive_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 1
 
 
 @dataclass(frozen=True)
@@ -48,15 +58,26 @@ class RuntimeConfig:
 
 
 @dataclass(frozen=True)
+class HarnessConfig:
+    agent: str = "opencode"
+    skill_mode: HarnessSkillMode = "no-skill"
+    usage_tracking: UsageTrackingPolicy = "required"
+    concurrency: int = 1
+    sandbox_setup_timeout_sec: int = 300
+    agent_idle_timeout_sec: int = 300
+    agent_timeout_sec: int = 900
+    reasoning_effort: str | None = None
+
+
+@dataclass(frozen=True)
 class TeacherConfig:
     enabled: bool = True
-    model: str = "glm-5.1"
-    api_key_env: str = "GLM_API_KEY"
-    base_url_env: str = "GLM_BASE_URL"
+    model: str = "glm/glm-5.1"
     max_attempts: int = 3
-    max_tokens: int = 4096
     min_verified: int = 1
-    temperature: float = 0.2
+    min_reward: float = 1.0
+    max_accepted_total_tokens: int = 200000
+    max_accepted_tool_calls: int = 50
 
 
 @dataclass(frozen=True)
@@ -95,6 +116,7 @@ class PipelineConfig:
     train_dataset: DatasetConfig
     eval_dataset: DatasetConfig
     runtime: RuntimeConfig = field(default_factory=RuntimeConfig)
+    harness: HarnessConfig = field(default_factory=HarnessConfig)
     teacher: TeacherConfig = field(default_factory=TeacherConfig)
     sft: SftConfig = field(default_factory=SftConfig)
     grpo: GrpoConfig = field(default_factory=GrpoConfig)
@@ -109,6 +131,25 @@ class PipelineConfig:
         errors: list[str] = []
         if self.runtime.integration not in {"benchflow", "openenv"}:
             errors.append("runtime.integration must be benchflow or openenv")
+        if self.harness.agent != "opencode":
+            errors.append("harness.agent must be opencode")
+        if self.harness.skill_mode not in {"no-skill", "with-skill"}:
+            errors.append("harness.skill_mode must be no-skill or with-skill")
+        if self.harness.usage_tracking != "required":
+            errors.append("harness.usage_tracking must be required")
+        if not _is_positive_int(self.harness.concurrency):
+            errors.append("harness.concurrency must be positive")
+        if not _is_positive_int(self.harness.sandbox_setup_timeout_sec):
+            errors.append("harness.sandbox_setup_timeout_sec must be positive")
+        if not _is_positive_int(self.harness.agent_idle_timeout_sec):
+            errors.append("harness.agent_idle_timeout_sec must be positive")
+        if not _is_positive_int(self.harness.agent_timeout_sec):
+            errors.append("harness.agent_timeout_sec must be positive")
+        if self.harness.reasoning_effort is not None and (
+            not isinstance(self.harness.reasoning_effort, str)
+            or not self.harness.reasoning_effort.strip()
+        ):
+            errors.append("harness.reasoning_effort must be a non-empty string")
         if self.runtime.openenv_url and self.runtime.integration != "openenv":
             errors.append("runtime.openenv_url requires integration = openenv")
         if (
@@ -133,8 +174,26 @@ class PipelineConfig:
             errors.append("grpo.gate_task_count must be positive")
         if self.grpo.max_steps < 1:
             errors.append("grpo.max_steps must be positive")
-        if self.teacher.max_attempts < 1 or self.teacher.min_verified < 1:
+        if not _is_positive_int(self.teacher.max_attempts) or not _is_positive_int(
+            self.teacher.min_verified
+        ):
             errors.append("teacher max_attempts and min_verified must be positive")
+        if (
+            not isinstance(self.teacher.model, str)
+            or not self.teacher.model.strip()
+            or "/" not in self.teacher.model
+        ):
+            errors.append("teacher.model must use provider/model format")
+        if (
+            not isinstance(self.teacher.min_reward, int | float)
+            or isinstance(self.teacher.min_reward, bool)
+            or not 0 <= float(self.teacher.min_reward) <= 1
+        ):
+            errors.append("teacher.min_reward must be between 0 and 1")
+        if not _is_positive_int(self.teacher.max_accepted_total_tokens):
+            errors.append("teacher.max_accepted_total_tokens must be positive")
+        if not _is_positive_int(self.teacher.max_accepted_tool_calls):
+            errors.append("teacher.max_accepted_tool_calls must be positive")
         if self.sft.max_steps < 1:
             errors.append("sft.max_steps must be positive")
         for label, path in (
@@ -157,6 +216,7 @@ def load_config(path: str | Path) -> PipelineConfig:
     train = _table(data, "train_dataset")
     eval_data = _table(data, "eval_dataset")
     runtime = _table(data, "runtime")
+    harness = _table(data, "harness", required=True)
     teacher = _table(data, "teacher")
     sft = _table(data, "sft")
     grpo = _table(data, "grpo")
@@ -179,6 +239,7 @@ def load_config(path: str | Path) -> PipelineConfig:
             path=str(eval_data.get("path", "tasks")),
         ),
         runtime=RuntimeConfig(**runtime),
+        harness=HarnessConfig(**harness),
         teacher=TeacherConfig(**teacher),
         sft=SftConfig(**sft),
         grpo=GrpoConfig(**grpo),

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/io.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/io.py
@@ -52,7 +52,7 @@ class CommandRunner:
         self.dry_run = dry_run
         self.commands: list[dict[str, Any]] = []
 
-    def run(self, name: str, command: list[str]) -> None:
+    def run(self, name: str, command: list[str], *, check: bool = True) -> int:
         record = {
             "name": name,
             "cwd": str(self.cwd),
@@ -65,5 +65,11 @@ class CommandRunner:
             file=sys.stderr,
             flush=True,
         )
-        if not self.dry_run:
-            subprocess.run(command, cwd=self.cwd, check=True)
+        if self.dry_run:
+            record["returncode"] = 0
+            return 0
+        result = subprocess.run(command, cwd=self.cwd, check=False)
+        record["returncode"] = result.returncode
+        if check and result.returncode:
+            raise subprocess.CalledProcessError(result.returncode, command)
+        return result.returncode

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/layout.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/layout.py
@@ -23,6 +23,10 @@ class RunLayout:
         return self.root / "data" / "verified_teacher_sft.jsonl"
 
     @property
+    def teacher_selection(self) -> Path:
+        return self.root / "reports" / "teacher_selection.json"
+
+    @property
     def jobs(self) -> Path:
         return self.root / "jobs"
 

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/pipeline.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/pipeline.py
@@ -62,6 +62,11 @@ class Pipeline:
             "train_task_count": len(self.train_task_ids),
             "eval_task_count": len(self.eval_task_ids),
             "runtime": asdict(self.config.runtime),
+            "harness": asdict(self.config.harness),
+            "harness_migration": {
+                "applied_stages": ["teacher"],
+                "pending_stages": ["evaluation", "grpo"],
+            },
             "teacher": asdict(self.config.teacher),
             "sft": asdict(self.config.sft),
             "grpo": asdict(self.config.grpo),
@@ -262,26 +267,22 @@ class Pipeline:
 
     def _collect_and_convert_teacher_data(self) -> None:
         manifest_path = self.layout.reports / "teacher_manifest.json"
-        if not (self.resume and manifest_path.is_file()):
-            if self.dry_run:
-                self.runner.commands.append(
-                    {
-                        "name": "collect_verified_teacher_rollouts",
-                        "call": "teacher.collect_verified_teacher_rollouts",
-                        "task_ids": self.train_task_ids,
-                        "jobs_dir": str(self.layout.jobs / "teacher"),
-                    }
-                )
-            else:
-                from .teacher import collect_verified_teacher_rollouts
+        if not (
+            self.resume
+            and manifest_path.is_file()
+            and self.layout.teacher_selection.is_file()
+        ):
+            from .teacher import collect_verified_teacher_rollouts
 
-                collect_verified_teacher_rollouts(
-                    config=self.config,
-                    tasks_dir=self.layout.train_tasks,
-                    task_ids=self.train_task_ids,
-                    jobs_dir=self.layout.jobs / "teacher",
-                    manifest_path=manifest_path,
-                )
+            collect_verified_teacher_rollouts(
+                config=self.config,
+                runner=self.runner,
+                tasks_dir=self.layout.train_tasks,
+                task_ids=self.train_task_ids,
+                jobs_dir=self.layout.jobs / "teacher",
+                manifest_path=manifest_path,
+                selection_path=self.layout.teacher_selection,
+            )
         conversion_manifest = self.layout.reports / "sft_conversion.json"
         if not (
             self.resume
@@ -298,9 +299,11 @@ class Pipeline:
                     "--out",
                     str(self.layout.sft_jsonl),
                     "--min-reward",
-                    "1.0",
+                    str(self.config.teacher.min_reward),
                     "--row-mode",
                     "rollout",
+                    "--canonical-selection",
+                    str(self.layout.teacher_selection),
                     "--manifest",
                     str(conversion_manifest),
                 ],
@@ -314,6 +317,8 @@ class Pipeline:
                 str(self.layout.sft_jsonl),
                 "--source-jobs",
                 str(self.layout.jobs / "teacher"),
+                "--source-canonical-selection",
+                str(self.layout.teacher_selection),
                 "--require-llm-trajectory",
                 "--require-tool-calls",
             ],
@@ -402,6 +407,11 @@ class Pipeline:
             "grpo_run_policy": self.config.grpo.run_policy,
             "grpo_planned": grpo_planned,
             "grpo_ran": grpo_ran,
+            "harness": asdict(self.config.harness),
+            "harness_migration": {
+                "applied_stages": ["teacher"],
+                "pending_stages": ["evaluation", "grpo"],
+            },
             "benchflow_commit": BENCHFLOW_COMMIT,
             "train_dataset": asdict(self.config.train_dataset),
             "eval_dataset": asdict(self.config.eval_dataset),

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/teacher.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/teacher.py
@@ -1,261 +1,369 @@
-"""Verified teacher-trajectory collection using BenchFlow's exact tools."""
+"""Verified teacher trajectories collected through BenchFlow and OpenCode."""
 
 from __future__ import annotations
 
 import json
-import os
-import time
 from pathlib import Path
 from typing import Any
 
 from .config import PipelineConfig
-from .integrations import build_environment_integration
-from .io import write_json
+from .io import CommandRunner, write_json
 
 
-TOOLS = [
-    {
-        "type": "function",
-        "function": {
-            "name": "run_bash",
-            "description": "Run a bash command in the task workspace.",
-            "parameters": {
-                "type": "object",
-                "properties": {"command": {"type": "string"}},
-                "required": ["command"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "submit",
-            "description": "Submit the final answer for verification.",
-            "parameters": {
-                "type": "object",
-                "properties": {"answer": {"type": "string"}},
-                "required": ["answer"],
-            },
-        },
-    },
-]
-
-
-def _as_dict(value: Any) -> dict[str, Any]:
-    if hasattr(value, "model_dump"):
-        return value.model_dump(exclude_none=True)
-    if isinstance(value, dict):
-        return dict(value)
-    raise TypeError(f"Unsupported provider object: {type(value)!r}")
-
-
-def _exchange(
-    *,
-    model: str,
-    request_messages: list[dict[str, Any]],
-    response: Any,
-    duration_ms: int,
-) -> dict[str, Any]:
-    return {
-        "request": {
-            "method": "POST",
-            "path": "/v1/chat/completions",
-            "body": {
-                "model": model,
-                "messages": request_messages,
-                "tools": TOOLS,
-                "tool_choice": "auto",
-            },
-        },
-        "response": {"status_code": 200, "body": _as_dict(response)},
-        "duration_ms": duration_ms,
-    }
-
-
-def write_trajectory(rollout_dir: Path, exchanges: list[dict[str, Any]]) -> Path:
-    path = rollout_dir / "trajectory" / "llm_trajectory.jsonl"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        "".join(json.dumps(row, sort_keys=True) + "\n" for row in exchanges)
-    )
-    return path
-
-
-def collect_verified_teacher_rollouts(
+def build_teacher_command(
     *,
     config: PipelineConfig,
     tasks_dir: Path,
     task_ids: list[str],
     jobs_dir: Path,
-    manifest_path: Path,
-) -> dict[str, Any]:
-    from openai import OpenAI
-
-    api_key = os.environ.get(config.teacher.api_key_env)
-    base_url = os.environ.get(config.teacher.base_url_env)
-    if not api_key or not base_url:
-        raise RuntimeError(
-            "Missing teacher credentials: "
-            f"{config.teacher.api_key_env} and {config.teacher.base_url_env}"
-        )
-    client = OpenAI(api_key=api_key, base_url=base_url)
-    integration = build_environment_integration(
-        config=config,
-        tasks_dir=tasks_dir,
-        task_ids=task_ids,
-        jobs_dir=jobs_dir,
-        reset_message=(
-            "Solve the task using run_bash to inspect the workspace. "
-            "Call submit exactly once with only the final answer."
+    task_manifest_path: Path,
+    run_config_path: Path,
+    health_path: Path,
+) -> list[str]:
+    if not task_ids:
+        raise ValueError("OpenCode teacher collection requires at least one task")
+    command = [
+        "bench",
+        "eval",
+        "run",
+        "--tasks-dir",
+        str(tasks_dir),
+        "--agent",
+        config.harness.agent,
+        "--model",
+        config.teacher.model,
+        "--sandbox",
+        config.sandbox,
+        "--skill-mode",
+        config.harness.skill_mode,
+        "--concurrency",
+        str(config.harness.concurrency),
+        "--usage-tracking",
+        config.harness.usage_tracking,
+        "--sandbox-setup-timeout",
+        str(config.harness.sandbox_setup_timeout_sec),
+        "--agent-idle-timeout",
+        str(config.harness.agent_idle_timeout_sec),
+        "--config-override",
+        json.dumps(
+            {"agent": {"timeout_sec": config.harness.agent_timeout_sec}},
+            separators=(",", ":"),
         ),
-    )
-    rows = {
-        row["benchflow_task_id"]: row for row in integration.train_dataset_rows
-    }
+        "--expected-tasks",
+        str(len(task_ids)),
+        "--task-manifest-out",
+        str(task_manifest_path),
+        "--run-config-out",
+        str(run_config_path),
+        "--health-summary-out",
+        str(health_path),
+        "--jobs-dir",
+        str(jobs_dir),
+    ]
+    if config.runtime.sandbox_user is not None:
+        command.extend(["--sandbox-user", config.runtime.sandbox_user])
+    if config.harness.reasoning_effort:
+        command.extend(["--reasoning-effort", config.harness.reasoning_effort])
+    for task_id in task_ids:
+        command.extend(["--include", task_id])
+    return command
+
+
+def _raw_results_row(rollout_dir: Path) -> dict[str, Any] | None:
+    path = rollout_dir / "results.jsonl"
+    if not path.is_file():
+        return None
+    rows = []
     try:
-        attempts: list[dict[str, Any]] = []
-        verified: list[dict[str, Any]] = []
-        for task_id in task_ids:
-            for attempt in range(1, config.teacher.max_attempts + 1):
-                env = integration.environment_factory()
-                row = rows[task_id]
-                reset_message = env.reset(**row)
-                if env.rollout_dir is None:
-                    raise RuntimeError("BenchFlow did not create a rollout directory")
-                messages = [dict(message) for message in row["prompt"]]
-                if reset_message:
-                    messages.append({"role": "user", "content": reset_message})
-                exchanges: list[dict[str, Any]] = []
-                submitted = False
-                error: str | None = None
-                try:
-                    for _ in range(config.runtime.max_tool_calling_iterations):
-                        request_messages = [dict(message) for message in messages]
-                        started = time.monotonic()
-                        response = client.chat.completions.create(
-                            model=config.teacher.model,
-                            messages=request_messages,
-                            tools=TOOLS,
-                            tool_choice="auto",
-                            temperature=config.teacher.temperature,
-                            max_tokens=config.teacher.max_tokens,
-                        )
-                        exchanges.append(
-                            _exchange(
-                                model=config.teacher.model,
-                                request_messages=request_messages,
-                                response=response,
-                                duration_ms=round(
-                                    (time.monotonic() - started) * 1000
-                                ),
-                            )
-                        )
-                        assistant = _as_dict(response.choices[0].message)
-                        assistant.setdefault("role", "assistant")
-                        assistant.setdefault("content", "")
-                        messages.append(assistant)
-                        tool_calls = assistant.get("tool_calls") or []
-                        if not tool_calls:
-                            messages.append(
-                                {
-                                    "role": "user",
-                                    "content": (
-                                        "Call run_bash to continue, or submit "
-                                        "the final answer."
-                                    ),
-                                }
-                            )
-                            continue
-                        for raw_call in tool_calls:
-                            call = _as_dict(raw_call)
-                            function = call.get("function", {})
-                            name = function.get("name")
-                            arguments = function.get("arguments", "{}")
-                            if isinstance(arguments, str):
-                                arguments = json.loads(arguments)
-                            if not isinstance(arguments, dict):
-                                raise ValueError(
-                                    f"Arguments for {name!r} must be an object"
-                                )
-                            if name == "run_bash":
-                                output = env.run_bash(
-                                    str(arguments.get("command", ""))
-                                )
-                            elif name == "submit":
-                                output = env.submit(str(arguments.get("answer", "")))
-                                submitted = True
-                            else:
-                                output = f"unsupported tool: {name}"
-                            messages.append(
-                                {
-                                    "role": "tool",
-                                    "tool_call_id": call.get("id"),
-                                    "content": output,
-                                }
-                            )
-                            if submitted:
-                                break
-                        if submitted:
-                            exchanges.append(
-                                _exchange(
-                                    model=config.teacher.model,
-                                    request_messages=[
-                                        dict(message) for message in messages
-                                    ],
-                                    response={
-                                        "choices": [
-                                            {
-                                                "message": {
-                                                    "role": "assistant",
-                                                    "content": (
-                                                        "Submission verified by "
-                                                        "the environment."
-                                                    ),
-                                                }
-                                            }
-                                        ]
-                                    },
-                                    duration_ms=0,
-                                )
-                            )
-                            break
-                except Exception as exc:
-                    error = f"{type(exc).__name__}: {exc}"
-                finally:
-                    if not submitted:
-                        integration.reward_funcs[0]([None], environments=[env])
-                    trajectory_path = write_trajectory(env.rollout_dir, exchanges)
-                    close = getattr(env, "_close", None)
-                    if callable(close):
-                        close()
-                result = {
-                    "task_id": task_id,
-                    "attempt": attempt,
-                    "reward": float(env.reward),
-                    "submitted": submitted,
-                    "rollout_dir": str(env.rollout_dir),
-                    "trajectory": str(trajectory_path),
-                    "exchange_count": len(exchanges),
-                    "error": error,
-                }
-                attempts.append(result)
-                print(json.dumps(result, sort_keys=True), flush=True)
-                if result["reward"] == 1.0:
-                    verified.append(result)
-                    break
-        manifest = {
+        for line in path.read_text().splitlines():
+            if line.strip():
+                rows.append(json.loads(line))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if len(rows) != 1 or not isinstance(rows[0], dict):
+        return None
+    return rows[0]
+
+
+def _results_row(rollout_dir: Path) -> dict[str, Any] | None:
+    row = _raw_results_row(rollout_dir)
+    if (
+        row is None
+        or not isinstance(row.get("info"), dict)
+        or row["info"].get("training_ready") is not True
+        or row.get("is_completed") is not True
+        or row.get("is_truncated") is not False
+        or row.get("stop_condition") != "agent_completed"
+        or row.get("error") is not None
+    ):
+        return None
+    return row
+
+
+def _token_total(row: dict[str, Any]) -> float | None:
+    usage = row.get("token_usage")
+    if not isinstance(usage, dict):
+        return None
+    total = usage.get("total_tokens")
+    if isinstance(total, int | float) and not isinstance(total, bool):
+        return float(total)
+    split_total = 0.0
+    found_split = False
+    for key in ("input_tokens", "output_tokens", "prompt_tokens", "completion_tokens"):
+        value = usage.get(key)
+        if isinstance(value, int | float) and not isinstance(value, bool):
+            found_split = True
+            split_total += float(value)
+    return split_total if found_split else None
+
+
+def _training_ready(rollout_dir: Path) -> bool:
+    row = _results_row(rollout_dir)
+    if row is None:
+        return False
+    total = _token_total(row)
+    return total is not None and total > 0
+
+
+def _valid_jsonl(path: Path) -> bool:
+    if not path.is_file():
+        return False
+    rows: list[dict[str, Any]] = []
+    allowed_types = {"user_message", "agent_message", "agent_thought", "tool_call"}
+    try:
+        for line in path.read_text().splitlines():
+            if line.strip():
+                row = json.loads(line)
+                if not isinstance(row, dict) or row.get("type") not in allowed_types:
+                    return False
+                event_type = row["type"]
+                if event_type in {"user_message", "agent_message", "agent_thought"}:
+                    if not isinstance(row.get("text"), str) or not row["text"].strip():
+                        return False
+                elif event_type == "tool_call":
+                    content = row.get("content")
+                    if (
+                        not isinstance(row.get("tool_call_id"), str)
+                        or not row["tool_call_id"]
+                        or not isinstance(row.get("title"), str)
+                        or not row["title"]
+                        or not isinstance(row.get("kind"), str)
+                        or not row["kind"]
+                        or row.get("status")
+                        not in {"pending", "in_progress", "completed", "failed"}
+                        or not isinstance(content, list)
+                        or not content
+                    ):
+                        return False
+                    for item in content:
+                        if (
+                            not isinstance(item, dict)
+                            or not isinstance(item.get("type"), str)
+                            or not item["type"]
+                        ):
+                            return False
+                        if item["type"] == "content":
+                            nested = item.get("content")
+                            if (
+                                not isinstance(nested, dict)
+                                or not isinstance(nested.get("type"), str)
+                                or not nested["type"]
+                            ):
+                                return False
+                            if nested["type"] == "text" and not isinstance(
+                                nested.get("text"), str
+                            ):
+                                return False
+                rows.append(row)
+    except (OSError, json.JSONDecodeError):
+        return False
+    event_types = {str(row["type"]) for row in rows}
+    return {
+        "user_message",
+        "tool_call",
+    }.issubset(event_types) and bool(event_types & {"agent_message", "agent_thought"})
+
+
+def _select_verified(
+    *,
+    config: PipelineConfig,
+    jobs_dir: Path,
+    task_ids: list[str],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    from benchflow.eval_artifacts import build_health_summary
+
+    health = build_health_summary(jobs_dir)
+    attempts: list[dict[str, Any]] = []
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for row in health["rows"]:
+        rollout_dir = Path(str(row.get("rollout_dir") or ""))
+        reward = row.get("reward")
+        training_ready = _training_ready(rollout_dir)
+        raw_results_row = _raw_results_row(rollout_dir)
+        total_tokens = (
+            _token_total(raw_results_row) if raw_results_row is not None else None
+        )
+        acp_trajectory_ready = _valid_jsonl(
+            rollout_dir / "trajectory" / "acp_trajectory.jsonl"
+        )
+        eligible = (
+            row.get("task_id") in task_ids
+            and row.get("scored") is True
+            and isinstance(reward, int | float)
+            and not isinstance(reward, bool)
+            and float(reward) >= config.teacher.min_reward
+            and row.get("valid_llm_trajectory") is True
+            and int(row.get("tool_calls") or 0) > 0
+            and int(row.get("tool_calls") or 0)
+            <= config.teacher.max_accepted_tool_calls
+            and row.get("error") is None
+            and row.get("verifier_error") is None
+            and training_ready
+            and acp_trajectory_ready
+            and total_tokens is not None
+            and total_tokens <= config.teacher.max_accepted_total_tokens
+        )
+        enriched = {
+            **row,
+            "training_ready": training_ready,
+            "acp_trajectory_ready": acp_trajectory_ready,
+            "total_tokens": total_tokens,
+            "eligible": eligible,
+        }
+        attempts.append(enriched)
+        grouped.setdefault(str(row.get("task_id")), []).append(enriched)
+    selected = []
+    for task_id in task_ids:
+        candidates = [row for row in grouped.get(task_id, []) if row["eligible"]]
+        if not candidates:
+            continue
+        winner = max(
+            candidates,
+            key=lambda row: (
+                float(row["reward"]),
+                int(row.get("tool_calls") or 0),
+                int(row.get("llm_trajectory_rows") or 0),
+            ),
+        )
+        selected.append(
+            {
+                **winner,
+                "selection_reason": "reward-then-tool-calls-then-trajectory-length",
+            }
+        )
+    return attempts, selected
+
+
+def collect_verified_teacher_rollouts(
+    *,
+    config: PipelineConfig,
+    runner: CommandRunner,
+    tasks_dir: Path,
+    task_ids: list[str],
+    jobs_dir: Path,
+    manifest_path: Path,
+    selection_path: Path,
+) -> dict[str, Any]:
+    remaining = list(task_ids)
+    for attempt in range(1, config.teacher.max_attempts + 1):
+        attempt_name = f"attempt-{attempt:02d}"
+        attempt_jobs = jobs_dir / attempt_name
+        returncode = runner.run(
+            (
+                "collect_verified_teacher_rollouts"
+                if attempt == 1
+                else f"collect_verified_teacher_rollouts_{attempt_name}"
+            ),
+            build_teacher_command(
+                config=config,
+                tasks_dir=tasks_dir,
+                task_ids=remaining,
+                jobs_dir=attempt_jobs,
+                task_manifest_path=manifest_path.with_name(
+                    f"teacher_task_manifest_{attempt_name}.json"
+                ),
+                run_config_path=manifest_path.with_name(
+                    f"teacher_run_config_{attempt_name}.json"
+                ),
+                health_path=manifest_path.with_name(
+                    f"teacher_health_{attempt_name}.json"
+                ),
+            ),
+            check=False,
+        )
+        if returncode not in {0, 1}:
+            raise RuntimeError(
+                f"OpenCode teacher attempt failed before rollout completion "
+                f"(exit {returncode})"
+            )
+        if runner.dry_run:
+            continue
+        attempts_so_far, selected_so_far = _select_verified(
+            config=config,
+            jobs_dir=jobs_dir,
+            task_ids=task_ids,
+        )
+        selected_task_ids = {str(row["task_id"]) for row in selected_so_far}
+        over_budget_task_ids = {
+            str(row["task_id"])
+            for row in attempts_so_far
+            if (
+                isinstance(row.get("total_tokens"), int | float)
+                and float(row["total_tokens"])
+                > config.teacher.max_accepted_total_tokens
+            )
+            or int(row.get("tool_calls") or 0) > config.teacher.max_accepted_tool_calls
+        }
+        remaining = [
+            task_id
+            for task_id in task_ids
+            if task_id not in selected_task_ids and task_id not in over_budget_task_ids
+        ]
+        if not remaining:
+            break
+    if runner.dry_run:
+        return {
             "teacher_model": config.teacher.model,
             "requested_task_count": len(task_ids),
-            "verified_count": len(verified),
-            "attempts": attempts,
-            "verified": verified,
+            "verified_count": None,
+            "attempts": [],
+            "verified": [],
         }
-        write_json(manifest_path, manifest)
-        if len(verified) < config.teacher.min_verified:
-            raise RuntimeError(
-                f"Only {len(verified)} verified trajectories; "
-                f"required {config.teacher.min_verified}"
-            )
-        return manifest
-    finally:
-        integration.close()
+    attempts, verified = _select_verified(
+        config=config,
+        jobs_dir=jobs_dir,
+        task_ids=task_ids,
+    )
+    selected_dirs = {str(row.get("rollout_dir")) for row in verified}
+    selection = {
+        "schema_version": 1,
+        "job_dir": str(jobs_dir),
+        "policy": "one-training-ready-per-task",
+        "selected_count": len(verified),
+        "selected": verified,
+        "rejected": [
+            row
+            for task_id in task_ids
+            for row in attempts
+            if row.get("task_id") == task_id
+            and str(row.get("rollout_dir")) not in selected_dirs
+        ],
+    }
+    write_json(selection_path, selection)
+    manifest = {
+        "teacher_model": config.teacher.model,
+        "harness": config.harness.agent,
+        "requested_task_count": len(task_ids),
+        "verified_count": len(verified),
+        "min_reward": config.teacher.min_reward,
+        "attempts": attempts,
+        "verified": verified,
+        "selection_path": str(selection_path),
+    }
+    write_json(manifest_path, manifest)
+    if len(verified) < config.teacher.min_verified:
+        raise RuntimeError(
+            f"Only {len(verified)} verified trajectories; "
+            f"required {config.teacher.min_verified}"
+        )
+    return manifest

--- a/pipelines/benchflow-task-posttrain/tests/test_config.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_config.py
@@ -19,6 +19,10 @@ def test_example_config_is_valid_and_pinned() -> None:
     assert config.eval_dataset.repo_id == "benchflow/data_agent_rl_environment_eval"
     assert len(config.train_dataset.revision) == 40
     assert len(config.eval_dataset.revision) == 40
+    assert config.harness.agent == "opencode"
+    assert config.harness.usage_tracking == "required"
+    assert config.teacher.model == "glm/glm-5.1"
+    assert config.teacher.min_reward == 1.0
     assert config.teacher.min_verified == 15
     assert config.runtime.num_generations == 2
     assert config.grpo.run_policy == "on_reward"
@@ -43,9 +47,7 @@ def test_config_accepts_always_grpo_run_policy(tmp_path: Path) -> None:
     configs.mkdir()
     config_path = configs / "always.toml"
     config_path.write_text(
-        source.read_text().replace(
-            'run_policy = "on_reward"', 'run_policy = "always"'
-        )
+        source.read_text().replace('run_policy = "on_reward"', 'run_policy = "always"')
     )
 
     config = load_config(config_path)
@@ -62,6 +64,152 @@ def test_config_rejects_unknown_grpo_run_policy() -> None:
         match="grpo.run_policy must be on_reward or always",
     ):
         config.validate()
+
+
+def test_config_rejects_non_opencode_harness() -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    config = replace(config, harness=replace(config.harness, agent="openhands"))
+
+    with pytest.raises(ValueError, match="harness.agent must be opencode"):
+        config.validate()
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("skill_mode", "invalid", "harness.skill_mode"),
+        ("usage_tracking", "auto", "harness.usage_tracking"),
+        ("concurrency", 0, "harness.concurrency"),
+        ("concurrency", -1, "harness.concurrency"),
+        ("concurrency", True, "harness.concurrency"),
+        ("concurrency", "1", "harness.concurrency"),
+        ("sandbox_setup_timeout_sec", 0, "harness.sandbox_setup_timeout_sec"),
+        ("sandbox_setup_timeout_sec", True, "harness.sandbox_setup_timeout_sec"),
+        ("agent_idle_timeout_sec", 0, "harness.agent_idle_timeout_sec"),
+        ("agent_idle_timeout_sec", "300", "harness.agent_idle_timeout_sec"),
+        ("agent_timeout_sec", 0, "harness.agent_timeout_sec"),
+        ("agent_timeout_sec", True, "harness.agent_timeout_sec"),
+        ("reasoning_effort", "", "harness.reasoning_effort"),
+        ("reasoning_effort", 1, "harness.reasoning_effort"),
+    ],
+)
+def test_config_rejects_invalid_harness_values(
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    config = replace(
+        config,
+        harness=replace(config.harness, **{field: value}),  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(ValueError, match=message):
+        config.validate()
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("model", "glm-5.1", "teacher.model"),
+        ("model", "", "teacher.model"),
+        ("model", 1, "teacher.model"),
+        ("max_attempts", 0, "teacher max_attempts"),
+        ("max_attempts", True, "teacher max_attempts"),
+        ("min_verified", 0, "teacher max_attempts"),
+        ("min_reward", -0.1, "teacher.min_reward"),
+        ("min_reward", 1.1, "teacher.min_reward"),
+        ("min_reward", True, "teacher.min_reward"),
+        (
+            "max_accepted_total_tokens",
+            0,
+            "teacher.max_accepted_total_tokens",
+        ),
+        (
+            "max_accepted_total_tokens",
+            True,
+            "teacher.max_accepted_total_tokens",
+        ),
+        (
+            "max_accepted_tool_calls",
+            0,
+            "teacher.max_accepted_tool_calls",
+        ),
+        (
+            "max_accepted_tool_calls",
+            "50",
+            "teacher.max_accepted_tool_calls",
+        ),
+    ],
+)
+def test_config_rejects_invalid_teacher_values(
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    config = replace(
+        config,
+        teacher=replace(config.teacher, **{field: value}),  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(ValueError, match=message):
+        config.validate()
+
+
+def test_config_requires_harness_table(tmp_path: Path) -> None:
+    source = ROOT / "configs/qwen3-4b-data-agent-smoke.toml"
+    text = source.read_text()
+    harness_start = text.index("[harness]")
+    teacher_start = text.index("[teacher]")
+    task_lists = tmp_path / "task-lists"
+    task_lists.mkdir()
+    for name in ("data-agent-train-15.txt", "data-agent-eval-2.txt"):
+        (task_lists / name).write_text((ROOT / "task-lists" / name).read_text())
+    configs = tmp_path / "configs"
+    configs.mkdir()
+    config_path = configs / "legacy.toml"
+    config_path.write_text(text[:harness_start] + text[teacher_start:])
+
+    with pytest.raises(ValueError, match=r"Missing required \[harness\] table"):
+        load_config(config_path)
+
+
+def test_config_rejects_non_table_harness(tmp_path: Path) -> None:
+    source = ROOT / "configs/qwen3-4b-data-agent-smoke.toml"
+    text = source.read_text()
+    harness_start = text.index("[harness]")
+    teacher_start = text.index("[teacher]")
+    task_lists = tmp_path / "task-lists"
+    task_lists.mkdir()
+    for name in ("data-agent-train-15.txt", "data-agent-eval-2.txt"):
+        (task_lists / name).write_text((ROOT / "task-lists" / name).read_text())
+    configs = tmp_path / "configs"
+    configs.mkdir()
+    config_path = configs / "bad-harness.toml"
+    config_path.write_text(
+        "harness = 1\n" + text[:harness_start] + text[teacher_start:]
+    )
+
+    with pytest.raises(ValueError, match=r"\[harness\] must be a TOML table"):
+        load_config(config_path)
+
+
+def test_config_accepts_non_default_opencode_harness_values() -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    config = replace(
+        config,
+        harness=replace(
+            config.harness,
+            skill_mode="with-skill",
+            concurrency=4,
+            sandbox_setup_timeout_sec=600,
+            agent_idle_timeout_sec=900,
+            reasoning_effort="high",
+        ),
+    )
+
+    config.validate()
 
 
 def test_config_rejects_conflicting_sandbox_aliases() -> None:
@@ -100,6 +248,8 @@ task_list = "missing-train.txt"
 repo_id = "eval"
 revision = "def"
 task_list = "missing-eval.txt"
+[harness]
+agent = "opencode"
 """
     )
 

--- a/pipelines/benchflow-task-posttrain/tests/test_io.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_io.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from posttrainarena.benchflow_pipeline.io import CommandRunner
+
+
+def test_command_runner_can_return_nonzero_without_raising(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=1),
+    )
+    runner = CommandRunner(cwd=tmp_path)
+
+    returncode = runner.run("teacher", ["bench", "eval", "run"], check=False)
+
+    assert returncode == 1
+    assert runner.commands[0]["returncode"] == 1
+
+
+def test_command_runner_still_raises_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=2),
+    )
+    runner = CommandRunner(cwd=tmp_path)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.run("invalid", ["bench", "bad"])
+
+
+def test_command_runner_dry_run_returns_success_without_subprocess(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError("subprocess should not run")
+
+    monkeypatch.setattr(subprocess, "run", unexpected)
+    runner = CommandRunner(cwd=tmp_path, dry_run=True)
+
+    assert runner.run("dry", ["bench", "eval", "run"]) == 0
+    assert runner.commands[0]["returncode"] == 0

--- a/pipelines/benchflow-task-posttrain/tests/test_pipeline.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_pipeline.py
@@ -20,6 +20,20 @@ def test_plan_exposes_public_stage_contract(tmp_path: Path) -> None:
 
     assert plan["train_task_count"] == 15
     assert plan["eval_task_count"] == 2
+    assert plan["harness"] == {
+        "agent": "opencode",
+        "skill_mode": "no-skill",
+        "usage_tracking": "required",
+        "concurrency": 1,
+        "sandbox_setup_timeout_sec": 300,
+        "agent_idle_timeout_sec": 300,
+        "agent_timeout_sec": 900,
+        "reasoning_effort": None,
+    }
+    assert plan["harness_migration"] == {
+        "applied_stages": ["teacher"],
+        "pending_stages": ["evaluation", "grpo"],
+    }
     assert plan["stages"][0] == "snapshot_train_tasks"
     assert plan["stages"][-1] == "write_score_report"
 
@@ -36,6 +50,14 @@ def test_dry_run_writes_score_schema_without_heavy_dependencies(tmp_path: Path) 
     assert saved["schema_version"] == 1
     assert saved["grpo_planned"] is True
     assert saved["grpo_ran"] is False
+    assert saved["harness"]["agent"] == "opencode"
+    assert saved["harness_migration"]["applied_stages"] == ["teacher"]
+    convert = next(
+        item
+        for item in saved["commands"]
+        if item["name"] == "convert_verified_sft_data"
+    )
+    assert convert["command"][convert["command"].index("--min-reward") + 1] == "1.0"
     assert len(saved["train_task_ids"]) == 15
     assert {item["name"] for item in saved["commands"]} >= {
         "snapshot_train_tasks",

--- a/pipelines/benchflow-task-posttrain/tests/test_teacher.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_teacher.py
@@ -1,41 +1,579 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
+from pathlib import Path
 
-from posttrainarena.benchflow_pipeline.teacher import TOOLS, _exchange
+import pytest
+
+from posttrainarena.benchflow_pipeline.config import load_config
+from posttrainarena.benchflow_pipeline.io import CommandRunner
+from posttrainarena.benchflow_pipeline.teacher import (
+    _select_verified,
+    _training_ready,
+    _valid_jsonl,
+    build_teacher_command,
+    collect_verified_teacher_rollouts,
+)
 
 
-def test_exchange_matches_benchflow_sft_converter_shape() -> None:
-    row = _exchange(
-        model="teacher",
-        request_messages=[{"role": "user", "content": "solve"}],
-        response={
-            "choices": [
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_training_ready_result(rollout: Path, *, total_tokens: int = 10) -> None:
+    (rollout / "results.jsonl").write_text(
+        json.dumps(
+            {
+                "info": {"training_ready": True},
+                "token_usage": {"total_tokens": total_tokens},
+                "is_completed": True,
+                "is_truncated": False,
+                "stop_condition": "agent_completed",
+                "error": None,
+            }
+        )
+        + "\n"
+    )
+
+
+def _write_complete_acp_trajectory(rollout: Path) -> None:
+    trajectory = rollout / "trajectory"
+    trajectory.mkdir(exist_ok=True)
+    (trajectory / "acp_trajectory.jsonl").write_text(
+        "\n".join(
+            json.dumps(row)
+            for row in (
+                {"type": "user_message", "text": "task"},
                 {
-                    "message": {
-                        "role": "assistant",
-                        "content": "",
-                        "tool_calls": [
-                            {
-                                "id": "call-1",
-                                "type": "function",
-                                "function": {
-                                    "name": "run_bash",
-                                    "arguments": json.dumps({"command": "ls"}),
-                                },
-                            }
-                        ],
-                    }
+                    "type": "tool_call",
+                    "tool_call_id": "call-1",
+                    "title": "bash",
+                    "kind": "execute",
+                    "status": "completed",
+                    "content": [
+                        {
+                            "type": "content",
+                            "content": {"type": "text", "text": "ok"},
+                        }
+                    ],
+                },
+                {"type": "agent_message", "text": "done"},
+            )
+        )
+        + "\n"
+    )
+
+
+class FakeRunner(CommandRunner):
+    def __init__(
+        self,
+        cwd: Path,
+        *,
+        dry_run: bool,
+        returncodes: list[int] | None = None,
+    ) -> None:
+        super().__init__(cwd=cwd, dry_run=dry_run)
+        self.returncodes = iter(returncodes or [])
+
+    def run(self, name: str, command: list[str], *, check: bool = True) -> int:
+        self.commands.append({"name": name, "command": command})
+        return next(self.returncodes, 0)
+
+
+def test_build_teacher_command_uses_opencode_and_required_telemetry(
+    tmp_path: Path,
+) -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    command = build_teacher_command(
+        config=config,
+        tasks_dir=tmp_path / "tasks",
+        task_ids=["task-a", "task-b"],
+        jobs_dir=tmp_path / "jobs",
+        task_manifest_path=tmp_path / "task-manifest.json",
+        run_config_path=tmp_path / "run-config.json",
+        health_path=tmp_path / "health.json",
+    )
+
+    assert command[command.index("--agent") + 1] == "opencode"
+    assert command[command.index("--model") + 1] == "glm/glm-5.1"
+    assert command[command.index("--usage-tracking") + 1] == "required"
+    assert command[command.index("--expected-tasks") + 1] == "2"
+    assert (
+        command[command.index("--config-override") + 1]
+        == '{"agent":{"timeout_sec":900}}'
+    )
+    assert command.count("--include") == 2
+    assert "--matrix" not in command
+    assert "--trials" not in command
+
+
+def test_build_teacher_command_rejects_empty_task_list(tmp_path: Path) -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+
+    with pytest.raises(ValueError, match="at least one task"):
+        build_teacher_command(
+            config=config,
+            tasks_dir=tmp_path / "tasks",
+            task_ids=[],
+            jobs_dir=tmp_path / "jobs",
+            task_manifest_path=tmp_path / "task-manifest.json",
+            run_config_path=tmp_path / "run-config.json",
+            health_path=tmp_path / "health.json",
+        )
+
+
+def test_build_teacher_command_supports_root_user_and_reasoning_effort(
+    tmp_path: Path,
+) -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    config = replace(
+        config,
+        runtime=replace(config.runtime, sandbox_user=None),
+        harness=replace(config.harness, reasoning_effort="high"),
+    )
+
+    command = build_teacher_command(
+        config=config,
+        tasks_dir=tmp_path / "tasks",
+        task_ids=["task-a"],
+        jobs_dir=tmp_path / "jobs",
+        task_manifest_path=tmp_path / "task-manifest.json",
+        run_config_path=tmp_path / "run-config.json",
+        health_path=tmp_path / "health.json",
+    )
+
+    assert "--sandbox-user" not in command
+    assert command[command.index("--reasoning-effort") + 1] == "high"
+
+
+def test_training_ready_requires_one_valid_row(tmp_path: Path) -> None:
+    rollout = tmp_path / "rollout"
+    rollout.mkdir()
+    assert _training_ready(rollout) is False
+
+    _write_training_ready_result(rollout)
+    assert _training_ready(rollout) is True
+
+    (rollout / "results.jsonl").write_text(
+        json.dumps(
+            {
+                "info": {"training_ready": True},
+                "token_usage": {"total_tokens": 10},
+                "is_completed": True,
+                "is_truncated": False,
+                "stop_condition": "agent_completed",
+                "error": None,
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "info": {"training_ready": True},
+                "token_usage": {"total_tokens": 10},
+                "is_completed": True,
+                "is_truncated": False,
+                "stop_condition": "agent_completed",
+                "error": None,
+            }
+        )
+        + "\n"
+    )
+    assert _training_ready(rollout) is False
+
+
+def test_training_ready_requires_positive_usage(tmp_path: Path) -> None:
+    rollout = tmp_path / "rollout"
+    rollout.mkdir()
+    (rollout / "results.jsonl").write_text(
+        json.dumps(
+            {
+                "info": {"training_ready": True},
+                "token_usage": {"total_tokens": 0},
+                "is_completed": True,
+                "is_truncated": False,
+                "stop_condition": "agent_completed",
+                "error": None,
+            }
+        )
+        + "\n"
+    )
+    assert _training_ready(rollout) is False
+
+    (rollout / "results.jsonl").write_text(
+        json.dumps(
+            {
+                "info": {"training_ready": True},
+                "token_usage": {"input_tokens": 7, "output_tokens": 3},
+                "is_completed": True,
+                "is_truncated": False,
+                "stop_condition": "agent_completed",
+                "error": None,
+            }
+        )
+        + "\n"
+    )
+    assert _training_ready(rollout) is True
+
+
+def test_valid_jsonl_requires_parseable_nonempty_file(tmp_path: Path) -> None:
+    path = tmp_path / "trajectory.jsonl"
+    assert _valid_jsonl(path) is False
+    path.write_text("")
+    assert _valid_jsonl(path) is False
+    path.write_text("{bad json}\n")
+    assert _valid_jsonl(path) is False
+    path.write_text("null\n")
+    assert _valid_jsonl(path) is False
+    path.write_text(
+        "\n".join(
+            json.dumps(row)
+            for row in (
+                {"type": "user_message", "text": "task"},
+                {
+                    "type": "tool_call",
+                    "tool_call_id": "call-1",
+                    "title": "bash",
+                    "kind": "execute",
+                    "status": "completed",
+                    "content": [
+                        {
+                            "type": "content",
+                            "content": {"type": "text", "text": "ok"},
+                        }
+                    ],
+                },
+                {"type": "agent_message", "text": "done"},
+            )
+        )
+        + "\n"
+    )
+    assert _valid_jsonl(path) is True
+
+    path.write_text(
+        "\n".join(
+            json.dumps(row)
+            for row in (
+                {"type": "user_message", "text": "task"},
+                {"type": "tool_call", "tool_call_id": ""},
+                {"type": "agent_message", "text": "done"},
+            )
+        )
+        + "\n"
+    )
+    assert _valid_jsonl(path) is False
+
+    path.write_text(
+        "\n".join(
+            json.dumps(row)
+            for row in (
+                {"type": "user_message", "text": "task"},
+                {
+                    "type": "tool_call",
+                    "tool_call_id": "call-1",
+                    "title": "bash",
+                    "kind": "execute",
+                    "status": "completed",
+                    "content": [{"type": "content"}],
+                },
+                {"type": "agent_message", "text": "done"},
+            )
+        )
+        + "\n"
+    )
+    assert _valid_jsonl(path) is False
+
+
+def test_select_verified_filters_unhealthy_and_picks_best(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    first = tmp_path / "task-a__first"
+    second = tmp_path / "task-a__second"
+    low = tmp_path / "task-b__low"
+    for rollout in (first, second, low):
+        rollout.mkdir()
+        _write_training_ready_result(rollout)
+        _write_complete_acp_trajectory(rollout)
+    rows = [
+        {
+            "task_id": "task-a",
+            "rollout_dir": str(first),
+            "reward": 1.0,
+            "scored": True,
+            "tool_calls": 2,
+            "valid_llm_trajectory": True,
+            "llm_trajectory_rows": 3,
+            "error": None,
+            "verifier_error": None,
+        },
+        {
+            "task_id": "task-a",
+            "rollout_dir": str(second),
+            "reward": 1.0,
+            "scored": True,
+            "tool_calls": 4,
+            "valid_llm_trajectory": True,
+            "llm_trajectory_rows": 5,
+            "error": None,
+            "verifier_error": None,
+        },
+        {
+            "task_id": "task-b",
+            "rollout_dir": str(low),
+            "reward": 0.5,
+            "scored": True,
+            "tool_calls": 3,
+            "valid_llm_trajectory": True,
+            "llm_trajectory_rows": 4,
+            "error": None,
+            "verifier_error": None,
+        },
+    ]
+    monkeypatch.setattr(
+        "benchflow.eval_artifacts.build_health_summary",
+        lambda _jobs_dir: {"rows": rows},
+    )
+
+    attempts, selected = _select_verified(
+        config=config,
+        jobs_dir=tmp_path,
+        task_ids=["task-a", "task-b"],
+    )
+
+    assert len(attempts) == 3
+    assert [row["task_id"] for row in selected] == ["task-a"]
+    assert selected[0]["rollout_dir"] == str(second)
+    assert selected[0]["training_ready"] is True
+    assert selected[0]["acp_trajectory_ready"] is True
+
+
+def test_select_verified_enforces_token_and_tool_budgets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rollout = tmp_path / "task-a__expensive"
+    rollout.mkdir()
+    _write_training_ready_result(rollout, total_tokens=100)
+    _write_complete_acp_trajectory(rollout)
+    monkeypatch.setattr(
+        "benchflow.eval_artifacts.build_health_summary",
+        lambda _jobs_dir: {
+            "rows": [
+                {
+                    "task_id": "task-a",
+                    "rollout_dir": str(rollout),
+                    "reward": 1.0,
+                    "scored": True,
+                    "tool_calls": 10,
+                    "valid_llm_trajectory": True,
+                    "llm_trajectory_rows": 3,
+                    "error": None,
+                    "verifier_error": None,
                 }
             ]
         },
-        duration_ms=3,
+    )
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    config = replace(
+        config,
+        teacher=replace(
+            config.teacher,
+            max_accepted_total_tokens=50,
+            max_accepted_tool_calls=5,
+        ),
     )
 
-    assert row["request"]["body"]["tools"] == TOOLS
-    assert (
-        row["response"]["body"]["choices"][0]["message"]["tool_calls"][0]["function"][
-            "name"
-        ]
-        == "run_bash"
+    attempts, selected = _select_verified(
+        config=config,
+        jobs_dir=tmp_path,
+        task_ids=["task-a"],
     )
+
+    assert attempts[0]["total_tokens"] == 100
+    assert attempts[0]["eligible"] is False
+    assert selected == []
+
+
+def test_teacher_config_accepts_fractional_reward_threshold() -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    config = replace(config, teacher=replace(config.teacher, min_reward=0.5))
+
+    config.validate()
+
+
+def test_collect_teacher_dry_run_records_all_possible_attempts(
+    tmp_path: Path,
+) -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    config = replace(
+        config,
+        teacher=replace(config.teacher, max_attempts=2, min_verified=1),
+    )
+    runner = FakeRunner(ROOT, dry_run=True)
+
+    manifest = collect_verified_teacher_rollouts(
+        config=config,
+        runner=runner,
+        tasks_dir=tmp_path / "tasks",
+        task_ids=["task-a", "task-b"],
+        jobs_dir=tmp_path / "jobs",
+        manifest_path=tmp_path / "reports" / "teacher.json",
+        selection_path=tmp_path / "reports" / "selection.json",
+    )
+
+    assert manifest["verified_count"] is None
+    assert [record["name"] for record in runner.commands] == [
+        "collect_verified_teacher_rollouts",
+        "collect_verified_teacher_rollouts_attempt-02",
+    ]
+    assert all(record["command"].count("--include") == 2 for record in runner.commands)
+
+
+def test_collect_teacher_retries_only_tasks_without_verified_rollout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    config = replace(
+        config,
+        teacher=replace(config.teacher, max_attempts=3, min_verified=2),
+    )
+    runner = FakeRunner(ROOT, dry_run=False)
+    task_a = {
+        "task_id": "task-a",
+        "rollout_dir": str(tmp_path / "task-a"),
+        "reward": 1.0,
+        "eligible": True,
+    }
+    task_b = {
+        "task_id": "task-b",
+        "rollout_dir": str(tmp_path / "task-b"),
+        "reward": 1.0,
+        "eligible": True,
+    }
+    responses = iter(
+        [
+            ([task_a], [task_a]),
+            ([task_a, task_b], [task_a, task_b]),
+            ([task_a, task_b], [task_a, task_b]),
+        ]
+    )
+    monkeypatch.setattr(
+        "posttrainarena.benchflow_pipeline.teacher._select_verified",
+        lambda **_kwargs: next(responses),
+    )
+
+    manifest = collect_verified_teacher_rollouts(
+        config=config,
+        runner=runner,
+        tasks_dir=tmp_path / "tasks",
+        task_ids=["task-a", "task-b"],
+        jobs_dir=tmp_path / "jobs",
+        manifest_path=tmp_path / "reports" / "teacher.json",
+        selection_path=tmp_path / "reports" / "selection.json",
+    )
+
+    assert manifest["verified_count"] == 2
+    assert len(runner.commands) == 2
+    assert runner.commands[0]["command"].count("--include") == 2
+    second_command = runner.commands[1]["command"]
+    assert second_command.count("--include") == 1
+    assert "task-b" in second_command
+    assert "task-a" not in second_command
+    selection = json.loads((tmp_path / "reports" / "selection.json").read_text())
+    assert selection["selected_count"] == 2
+
+
+def test_collect_teacher_retries_after_rollout_exit_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    config = replace(
+        config,
+        teacher=replace(config.teacher, max_attempts=2, min_verified=1),
+    )
+    runner = FakeRunner(ROOT, dry_run=False, returncodes=[1, 0])
+    selected = {
+        "task_id": "task-a",
+        "rollout_dir": str(tmp_path / "task-a"),
+        "reward": 1.0,
+        "eligible": True,
+    }
+    responses = iter([([], []), ([selected], [selected]), ([selected], [selected])])
+    monkeypatch.setattr(
+        "posttrainarena.benchflow_pipeline.teacher._select_verified",
+        lambda **_kwargs: next(responses),
+    )
+
+    manifest = collect_verified_teacher_rollouts(
+        config=config,
+        runner=runner,
+        tasks_dir=tmp_path / "tasks",
+        task_ids=["task-a"],
+        jobs_dir=tmp_path / "jobs",
+        manifest_path=tmp_path / "reports" / "teacher.json",
+        selection_path=tmp_path / "reports" / "selection.json",
+    )
+
+    assert manifest["verified_count"] == 1
+    assert len(runner.commands) == 2
+
+
+def test_collect_teacher_rejects_cli_usage_error(tmp_path: Path) -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    runner = FakeRunner(ROOT, dry_run=False, returncodes=[2])
+
+    with pytest.raises(RuntimeError, match="exit 2"):
+        collect_verified_teacher_rollouts(
+            config=config,
+            runner=runner,
+            tasks_dir=tmp_path / "tasks",
+            task_ids=["task-a"],
+            jobs_dir=tmp_path / "jobs",
+            manifest_path=tmp_path / "reports" / "teacher.json",
+            selection_path=tmp_path / "reports" / "selection.json",
+        )
+
+
+def test_collect_teacher_does_not_retry_over_budget_task(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    config = replace(
+        config,
+        teacher=replace(
+            config.teacher,
+            max_attempts=3,
+            min_verified=1,
+            max_accepted_total_tokens=50,
+        ),
+    )
+    runner = FakeRunner(ROOT, dry_run=False, returncodes=[0])
+    attempt = {
+        "task_id": "task-a",
+        "rollout_dir": str(tmp_path / "task-a"),
+        "reward": 1.0,
+        "tool_calls": 2,
+        "total_tokens": 100,
+        "eligible": False,
+    }
+    monkeypatch.setattr(
+        "posttrainarena.benchflow_pipeline.teacher._select_verified",
+        lambda **_kwargs: ([attempt], []),
+    )
+
+    with pytest.raises(RuntimeError, match="Only 0 verified trajectories"):
+        collect_verified_teacher_rollouts(
+            config=config,
+            runner=runner,
+            tasks_dir=tmp_path / "tasks",
+            task_ids=["task-a"],
+            jobs_dir=tmp_path / "jobs",
+            manifest_path=tmp_path / "reports" / "teacher.json",
+            selection_path=tmp_path / "reports" / "selection.json",
+        )
+
+    assert len(runner.commands) == 1


### PR DESCRIPTION
## Summary

- make `[harness]` an explicit OpenCode-only recipe contract and record the migration stage in plan and score artifacts
- replace the handwritten OpenAI `run_bash` / `submit` teacher loop with `bench eval run --agent opencode`
- retry only tasks without a verified rollout, treat rollout exit 1 as retryable, and abort on CLI/config errors
- select one reward-qualified, training-ready rollout per task with complete ACP/LLM/results artifacts, positive usage, and configurable acceptance ceilings
- feed the canonical selection into the existing BenchFlow SFT converter and validator
- document that teacher collection is migrated while evaluation and GRPO remain pending follow-up PRs

## Test Coverage

All new teacher orchestration, configuration validation, retry, budget, artifact-health, and command-runner paths have unit coverage.

Tests: 13 → 14 files (+1 new test module).

## Pre-Landing Review

Independent structured review findings were addressed:

- retryable BenchFlow exit handling
- enforceable wall-clock timeout mapping
- terminal handling for over-budget attempts
- strict ACP event structure
- completed-result and positive-usage requirements
- truthful migration metadata in `plan.json` and `score.json`

## Design Review

No frontend files changed — design review skipped.

## Eval Results

- 83/83 package tests passed
- changed-file Ruff checks passed
- real SkillsBench `3d-scan-calc` canary passed through OpenCode + `glm/glm-5.1` + Daytona
- reward: `1.0`; tool calls: `10`; tokens: `109,321`; telemetry: `100%`
- `benchflow-experiment-review` validator: healthy, 0 issues
- `bench train convert` and `bench train validate`: 1 canonical tool-using row passed
- exact Daytona sandbox ID was absent after completion, confirming cleanup

## Scope Drift

Scope Check: CLEAN. This PR migrates teacher collection only. OpenCode evaluation and GRPO are explicitly deferred to the next migration PRs.

## Plan Completion

This is the first runtime increment of the OpenCode-only refactor. Teacher collection is complete; evaluation and GRPO remain intentionally pending.

## Test plan

- [x] Full pytest suite passes
- [x] Changed Python files pass Ruff
- [x] Dry-run emits three possible adaptive teacher attempts with OpenCode
- [x] Real OpenCode + Daytona teacher rollout is healthy and converter-ready
- [x] Retryable exit, usage error, budget, malformed artifact, and resume paths are covered