### PR TITLE
Migrate evaluation to OpenCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The checked-in implementation is intentionally smaller than the draft competitio
 | --- | --- |
 | Participant task format and local validation | **Implemented** — eight worked examples, structural checks, Docker oracle replay, and empty-trial rejection |
 | BenchFlow task-list training and evaluation | **Implemented** — pinned snapshots, verified teacher collection, LoRA SFT, reward-gated or forced GRPO, held-out evaluation, and score reports |
+| OpenCode harness migration | **Teacher and evaluation implemented** — teacher collection, baseline/gate/final eval, and benchmark matrices use OpenCode; GRPO rollout generation and endpoint resync remain in migration |
 | Public data | **Available** — [2,238 training tasks](https://huggingface.co/datasets/benchflow/data_agent_rl_environment_train) and [366 held-out evaluation tasks](https://huggingface.co/datasets/benchflow/data_agent_rl_environment_eval) in native `task.md` format |
 | OpenEnv protocol path | **Implemented** — served adapter, typed client, lifecycle tests, Docker parity validation, and a native-dataset end-to-end smoke |
 | HF Jobs execution | **Implemented** — portable UV job bundles, pinned code refs, named-secret boundaries, status inspection, and Hub publishing; live scheduler allocation currently awaits HF credits |
@@ -53,7 +54,7 @@ The checked-in implementation is intentionally smaller than the draft competitio
 | Demonstrated model-quality lift | **Not yet** — completed smokes validated system mechanics, not learning gains |
 
 > [!NOTE]
-> On July 10, 2026, a real one-train/one-held-out run completed snapshotting, baseline evaluation, verifier-approved teacher collection, LoRA SFT, a forced GRPO step, final evaluation, and artifact publication through the OpenEnv path. Scores remained `0.0 → 0.0`, so this is evidence of end-to-end operability—not quality improvement. See the [native-dataset OpenEnv smoke report](https://github.com/benchflow-ai/posttrainarena/blob/main/docs/native-dataset-openenv-smoke.md).
+> On July 10, 2026, a real one-train/one-held-out run completed snapshotting, baseline evaluation, verifier-approved teacher collection, LoRA SFT, a forced GRPO step, final evaluation, and artifact publication through the earlier OpenEnv/TRL evaluation path. Scores remained `0.0 → 0.0`, so this is evidence of end-to-end operability—not quality improvement and not validation of the newer OpenCode evaluation path. See the [native-dataset OpenEnv smoke report](https://github.com/benchflow-ai/posttrainarena/blob/main/docs/native-dataset-openenv-smoke.md).
 
 For compatibility details and evidence boundaries, use [Architecture and implementation status](./docs/architecture-status.md) as the source of truth.
 

--- a/docs/architecture-status.md
+++ b/docs/architecture-status.md
@@ -34,15 +34,18 @@ PostTrain task lists and pinned HF snapshots
     -> OpenCode teacher rollouts through BenchFlow
     -> verifier-approved, training-ready teacher trajectories
     -> TRL LoRA SFT and merged checkpoint
-    -> legacy TRL environment_factory reward gate and optional GRPO
-    -> legacy TRL environment_factory held-out evaluation and paired lift report
+    -> OpenCode training-task reward gate through BenchFlow
+    -> legacy TRL environment_factory optional GRPO
+    -> OpenCode held-out evaluation and paired lift report
 ```
 
-Teacher collection now uses OpenCode as its agent harness with required provider
-telemetry and BenchFlow artifact-health gates. Evaluation and GRPO still use the
-older TRL-owned `run_bash` / `submit` loop in this migration stage; follow-up
-changes will move those stages to the same OpenCode harness before the legacy
-environment path is removed.
+Teacher collection and every evaluation stage now use OpenCode as the agent
+harness with required provider telemetry and BenchFlow artifact-health gates.
+Only GRPO rollout generation still uses the older TRL-owned `run_bash` /
+`submit` loop. Evaluation resolves the base and student model aliases plus the
+OpenAI-compatible endpoint from named environment variables. The endpoint must
+already expose the checkpoint selected for that stage; the GRPO migration owns
+automatic policy-to-endpoint resynchronization.
 
 The final machine-readable contract is:
 
@@ -76,11 +79,12 @@ competition-scale readiness.
 | TRL SFT | Implemented | Tool-aware LoRA SFT and merged checkpoint path |
 | TRL GRPO | Implemented | Reward-gated by default; explicit `always` policy supports zero-reward plumbing runs |
 | OpenCode teacher collection | Implemented | Provider-qualified teacher model, required usage tracking, adaptive retries, and one training-ready rollout selected per task |
-| OpenCode evaluation and GRPO | In migration | Teacher collection is migrated; evaluation and GRPO still use the legacy TRL environment loop |
+| OpenCode evaluation | Implemented | Baseline, post-SFT, training gate, final, and multi-benchmark evaluation all use `bench eval run --agent opencode`; the real SkillsBench + Daytona canary passed with complete telemetry and healthy trajectories |
+| OpenCode GRPO | In migration | GRPO rollout generation and policy-to-endpoint resynchronization still use the legacy TRL environment loop |
 | Harbor | Not a dependency | No Harbor adapter or trajectory translation is used |
 | OpenEnv client/server lifecycle | Implemented | Pinned dependency, served adapter, typed client, real lifecycle tests, finalization, state, and session isolation |
 | OpenEnv/BenchFlow Docker parity | Manually validated | Checked-in security task produced identical output and reward `1.0` through both integrations; CI uses a no-spend fake BenchFlow boundary |
-| Native dataset OpenEnv pipeline | End-to-end smoke validated | One train and one held-out native `task.md` package completed snapshot, teacher collection, SFT, forced GRPO, final eval, and artifact publication; see `docs/native-dataset-openenv-smoke.md` |
+| Native dataset OpenEnv pipeline | Prior end-to-end smoke validated | One train and one held-out native `task.md` package completed the earlier OpenEnv/TRL eval path; rerun the current OpenCode-eval path after a student endpoint is configured |
 | Submission-to-recipe bridge | Implemented | Environment entries become pinned Hub datasets and portable recipes |
 | HF Jobs execution | Implemented; scheduler credit blocked | UV job bundle and exact H100 runner validated; HF API allocation currently returns HTTP 402 until Jobs credits are granted |
 | Hub artifact publishing | Implemented | Run reports, checkpoint provenance, logs, and failures publish to Hub datasets/models |
@@ -89,9 +93,16 @@ competition-scale readiness.
 | Final Qwen3-8B competition recipe | Draft | Current reproducible reference pins Qwen3-4B |
 | Demonstrated model-quality lift | Not yet | Reproduced smoke measured zero lift |
 
+The OpenCode evaluation evidence is recorded in
+[`opencode-evaluation-canary.md`](opencode-evaluation-canary.md).
+
 ## OpenEnv integration
 
-The supported path is:
+OpenEnv is currently confined to the temporary legacy GRPO integration.
+Teacher collection and evaluation invoke BenchFlow directly through the
+OpenCode-backed `bench eval run` path.
+
+The supported GRPO path is:
 
 ```text
 TRL

--- a/docs/hf-jobs-validation.md
+++ b/docs/hf-jobs-validation.md
@@ -6,6 +6,12 @@ The PostTrain Arena Hugging Face handoff is implemented and its exact UV runner
 has completed the full pipeline on an H100. Allocation through the HF Jobs
 scheduler is currently blocked by account credits, not code.
 
+This July 11 evidence predates the OpenCode evaluation migration. It validates
+the HF bundle, trainer, publishing, and earlier TRL evaluation path. The current
+OpenCode evaluator has separate real SkillsBench + Daytona canary evidence, but
+the full HF H100 flow must be rerun after a student endpoint and automatic
+checkpoint resynchronization are available.
+
 ## Validated flow
 
 Run: `hf-wrapper-h100-fixed-20260711T010948Z`

--- a/docs/hf-jobs.md
+++ b/docs/hf-jobs.md
@@ -100,8 +100,9 @@ posttrainarena-train hf-job-submit \
 ```
 
 Default full-run secrets are `HF_TOKEN`, `DAYTONA_API_KEY`, `GLM_API_KEY`,
-`GLM_BASE_URL`, `OPENAI_API_KEY`, and `WANDB_API_KEY`. Override the list with
-repeated `--secret-env NAME`.
+`GLM_BASE_URL`, `BENCHFLOW_BASE_MODEL`, `BENCHFLOW_ADAPTER_MODEL`,
+`BENCHFLOW_PROVIDER_BASE_URL`, `BENCHFLOW_PROVIDER_API_KEY`, and
+`WANDB_API_KEY`. Override the list with repeated `--secret-env NAME`.
 
 ## 4. Inspect a job
 

--- a/docs/native-dataset-openenv-smoke.md
+++ b/docs/native-dataset-openenv-smoke.md
@@ -3,6 +3,10 @@
 On July 10, 2026, PostTrain Arena completed a real one-train/one-held-out
 end-to-end run against the public BenchFlow-native data-agent datasets.
 
+This historical run used the earlier TRL/OpenEnv evaluation loop. It does not
+validate the newer OpenCode baseline/gate/final evaluator or the still-pending
+OpenCode GRPO endpoint-resynchronization path.
+
 ## Pinned inputs
 
 - PostTrain Arena: `fbdd7c2`
@@ -52,4 +56,3 @@ confirmed terminated.
 
 The run emitted the known non-fatal asynchronous Daytona cleanup warning after
 score artifacts were written. No run sandbox remained active.
-

--- a/docs/opencode-evaluation-canary.md
+++ b/docs/opencode-evaluation-canary.md
@@ -1,0 +1,38 @@
+# OpenCode evaluation canary
+
+On July 12, 2026, the migrated evaluator ran the real SkillsBench
+`3d-scan-calc` task through BenchFlow, OpenCode, and Daytona.
+
+## Contract
+
+- BenchFlow: `6eaa14344bd835a3c2c5c31a31470ef994b24a80`
+- Agent: `opencode`
+- Model: `glm/glm-5.1`
+- Sandbox: `daytona`
+- Skill mode: `no-skill`
+- Usage tracking: `required`
+- Selected tasks: exactly one
+
+The pipeline invoked the same production command builder used by baseline,
+training-gate, final, and benchmark-matrix evaluation. Endpoint credentials
+were supplied only through process environment variables.
+
+## Result
+
+- Score: `1/1`
+- Agent errors: `0`
+- Verifier errors: `0`
+- Telemetry coverage: `100%`
+- Total tokens: `134,340`
+- Tool calls: `13`
+- `results.jsonl` rows: `1`
+- `llm_trajectory.jsonl` rows: `13`
+- Training-ready result: `true`
+- Missing or malformed LLM trajectories: `0`
+- Unscored or zero-tool rows: `0`
+
+This proves the OpenCode evaluation command, endpoint environment mapping,
+Daytona execution, verifier scoring, and fail-closed artifact-health checks.
+It does not prove evaluation of a newly trained checkpoint; that requires the
+student endpoint to load the checkpoint before evaluation. Automatic
+policy-to-endpoint synchronization remains part of the GRPO migration.

--- a/docs/training-pipeline.md
+++ b/docs/training-pipeline.md
@@ -13,21 +13,22 @@ implemented OpenEnv adapter boundary, see
 ```text
 training task list + held-out eval task list + pinned TOML recipe
     -> snapshot task packages from Hugging Face
-    -> evaluate the base model
+    -> evaluate the served base model through OpenCode
     -> collect verifier-approved teacher trajectories through OpenCode
     -> convert and validate tool-aware SFT data
     -> train and merge a LoRA SFT checkpoint
-    -> evaluate a training-task reward gate
+    -> evaluate the served student model on a training-task reward gate
     -> run GRPO according to the configured run policy
-    -> evaluate the final model on held-out tasks
+    -> evaluate the served final model through OpenCode on held-out tasks
     -> write paired lift and score reports
 ```
 
 BenchFlow owns task snapshots, Daytona or Docker sandboxes, verifiers, reward
 extraction, rollout artifacts, and paired evaluation. OpenCode owns the teacher
-agent loop. TRL owns SFT and GRPO optimization. Evaluation and GRPO still use
-the legacy TRL-owned `run_bash` / `submit` loop during this migration stage.
-The pipeline is Harbor-free and does not translate Harbor trajectories.
+and evaluation agent loops. TRL owns SFT and GRPO optimization. GRPO rollout
+generation is the only stage still using the legacy TRL-owned `run_bash` /
+`submit` loop during this migration stage. The pipeline is Harbor-free and
+does not translate Harbor trajectories.
 
 The default recipes pin the public BenchFlow-native conversions:
 
@@ -41,10 +42,11 @@ SFT, forced-GRPO, final-eval, and publication path on these revisions. See
 [`native-dataset-openenv-smoke.md`](native-dataset-openenv-smoke.md) for the
 exact evidence and claim boundary.
 
-OpenEnv is an optional protocol adapter in front of the same BenchFlow engine.
-The adapter exposes a real served `Environment` and typed `EnvClient`; it does
-not duplicate BenchFlow task loading, sandboxes, verifiers, rewards, artifacts,
-or held-out evaluation.
+OpenEnv is an optional protocol adapter for the temporary legacy GRPO path in
+front of the same BenchFlow engine. Teacher collection and evaluation use the
+OpenCode-backed BenchFlow CLI directly. The adapter exposes a real served
+`Environment` and typed `EnvClient`; it does not duplicate BenchFlow task
+loading, sandboxes, verifiers, rewards, artifacts, or held-out evaluation.
 
 `runtime.openenv_url` currently supports only deployments that share the task
 snapshot and BenchFlow artifact filesystem with the pipeline process. A fully
@@ -57,17 +59,19 @@ evaluation, the reward gate, and GRPO rollouts.
 ```mermaid
 flowchart LR
     Input["PostTrain task packages + pinned recipe"] --> Pipeline["PostTrain pipeline"]
+    Pipeline --> OC["OpenCode teacher + evaluation"]
+    OC --> BF["BenchFlow task + verifier"]
     Pipeline --> TRL["TRL SFT + GRPO"]
-    TRL --> Backend{"Environment integration"}
+    TRL --> Backend{"Temporary GRPO environment integration"}
     Backend --> Direct["Direct BenchFlow"]
     Backend --> OE["OpenEnv protocol"]
-    OE --> BF["BenchFlow task + verifier"]
+    OE --> BF
     Direct --> BF
     BF --> Runtime["Docker / Daytona"]
     Runtime --> BF
     BF --> TRL
-    TRL --> Eval["Held-out BenchFlow evaluation"]
-    Eval --> Output["score.json + paired lift artifacts"]
+    BF --> Output["score.json + paired lift artifacts"]
+    TRL --> Pipeline
 ```
 
 ## Public contract
@@ -145,7 +149,8 @@ Dry-run records the full possible path, including conditional GRPO. Therefore
 | `[train_dataset]` | HF task repository, revision, path, and training task-list file |
 | `[eval_dataset]` | Separate HF repository/revision and held-out task-list file |
 | `[runtime]` | Direct/OpenEnv integration, Daytona/Docker sandbox, tool limits, generation counts, and vLLM toggle |
-| `[harness]` | Required OpenCode contract, skill mode, telemetry, concurrency, and setup/idle/wall-clock timeouts; currently applied to teacher collection while evaluation and GRPO migrate in follow-up releases |
+| `[harness]` | Required OpenCode contract, skill mode, telemetry, concurrency, and setup/idle/wall-clock timeouts for teacher collection and evaluation |
+| `[evaluation]` | Environment-variable names for the served base/student model aliases and OpenAI-compatible endpoint credentials |
 | `[teacher]` | Provider-qualified teacher model, adaptive attempts, reward threshold, post-run token/tool acceptance ceilings, and required verified rows |
 | `[sft]` | Enable flag, optimizer settings, sequence length, and LoRA dimensions |
 | `[grpo]` | Enable flag, run policy, training-task gate threshold/count, optimizer settings, and steps |
@@ -166,6 +171,10 @@ The example Daytona recipe expects:
 - `HF_TOKEN` when private or gated snapshots require it
 - `DAYTONA_API_KEY` for sandbox creation
 - `GLM_API_KEY` and `GLM_BASE_URL` for its OpenCode-driven GLM teacher
+- `BENCHFLOW_BASE_MODEL` and `BENCHFLOW_ADAPTER_MODEL` for the OpenCode
+  baseline and current-student model aliases
+- `BENCHFLOW_PROVIDER_BASE_URL` and `BENCHFLOW_PROVIDER_API_KEY` for the
+  OpenAI-compatible model endpoint used by OpenCode evaluation
 - `WANDB_API_KEY` when `tracking.report_to = "wandb"`
 - any task-specific credentials required by selected verifiers
 
@@ -187,6 +196,18 @@ posttrainarena-train run \
 Resume reuses snapshots, evaluation metrics, converted SFT data, and checkpoints
 when their expected marker artifacts exist. Use a new run name when changing a
 recipe or task list.
+
+Before a post-SFT or post-GRPO evaluation, the configured student endpoint must
+serve the checkpoint under `BENCHFLOW_ADAPTER_MODEL`. This evaluation slice
+fails closed on missing endpoint configuration, incomplete token telemetry,
+missing or malformed LLM trajectories, unscored rows, and zero-tool rollouts.
+Automatic endpoint resynchronization is part of the OpenCode GRPO rollout
+refactor.
+
+The evaluator itself has a real SkillsBench + Daytona canary with score `1.0`,
+complete provider telemetry, and healthy `results.jsonl` and
+`llm_trajectory.jsonl` artifacts. See
+[`opencode-evaluation-canary.md`](opencode-evaluation-canary.md).
 
 ## SFT, RL-only, and reward gating
 

--- a/pipelines/benchflow-task-posttrain/README.md
+++ b/pipelines/benchflow-task-posttrain/README.md
@@ -1,8 +1,9 @@
 # BenchFlow Task-List Post-Training Pipeline
 
 This is the public, reproducible training path for running SFT and optional
-GRPO over BenchFlow-compatible task suites. TRL can drive BenchFlow directly
-or through a real OpenEnv client/server protocol adapter.
+GRPO over BenchFlow-compatible task suites. OpenCode drives teacher collection
+and evaluation; the temporary legacy GRPO path lets TRL drive BenchFlow
+directly or through a real OpenEnv client/server protocol adapter.
 
 The repository-wide architecture and compatibility status is documented in
 [`docs/architecture-status.md`](../../docs/architecture-status.md). In
@@ -22,10 +23,10 @@ training task list + held-out eval task list + TOML recipe
 ```
 
 BenchFlow owns task snapshots, sandbox lifecycle, verifiers, rollout artifacts,
-and paired evaluation. OpenCode owns teacher-model interaction. TRL owns SFT
-and GRPO optimization. Evaluation and GRPO remain on the legacy TRL-owned tool
-loop until their follow-up migration changes land. OpenEnv is an optional
-protocol for that legacy path, not a second runtime or eval engine. The default
+and paired evaluation. OpenCode owns teacher and evaluation model interaction.
+TRL owns SFT and GRPO optimization. Only GRPO rollouts remain on the legacy
+TRL-owned tool loop. OpenEnv is an optional protocol for that temporary GRPO
+path, not a second runtime or eval engine. The default
 recipes pin the public BenchFlow-native `task.md` datasets
 `benchflow/data_agent_rl_environment_train` and
 `benchflow/data_agent_rl_environment_eval`. The pipeline does not depend on
@@ -44,8 +45,9 @@ benchflow-task-posttrain/
   src/.../config.py        typed TOML contract and validation
   src/.../pipeline.py      resumable stage orchestration
   src/.../teacher.py       verified OpenCode teacher rollouts
+  src/.../opencode.py      OpenCode baseline/gate/final evaluation
   src/.../sft.py           tool-aware LoRA SFT and weight merge
-  src/.../policy.py        BenchFlow-backed eval and GRPO
+  src/.../policy.py        temporary legacy GRPO rollout integration
   src/.../openenv/         OpenEnv client/server protocol adapter
   tests/                   no-spend contract tests
 ```
@@ -102,6 +104,10 @@ The example recipe requires:
 - `HF_TOKEN` for task snapshots and optional artifact publication
 - `DAYTONA_API_KEY` for `runtime.sandbox = "daytona"`
 - `GLM_API_KEY` and `GLM_BASE_URL` for the example OpenCode teacher model
+- `BENCHFLOW_BASE_MODEL` and `BENCHFLOW_ADAPTER_MODEL` for the served base and
+  current-student model aliases
+- `BENCHFLOW_PROVIDER_BASE_URL` and `BENCHFLOW_PROVIDER_API_KEY` for the
+  OpenAI-compatible endpoint used by OpenCode evaluation
 - `WANDB_API_KEY` when `tracking.report_to = "wandb"`
 - any verifier-specific credentials required by the selected task packages
 
@@ -117,6 +123,10 @@ posttrainarena-train run \
 
 Use `--resume` after interruption. Completed snapshots, evaluations, and
 checkpoints are reused when their expected marker artifacts exist.
+
+The endpoint named by the evaluation environment variables must already serve
+the checkpoint selected for the stage. Automatic student endpoint
+resynchronization is part of the remaining OpenCode GRPO migration.
 
 The final contract is:
 

--- a/pipelines/benchflow-task-posttrain/configs/qwen3-4b-data-agent-openenv-smoke.toml
+++ b/pipelines/benchflow-task-posttrain/configs/qwen3-4b-data-agent-openenv-smoke.toml
@@ -37,6 +37,12 @@ sandbox_setup_timeout_sec = 300
 agent_idle_timeout_sec = 300
 agent_timeout_sec = 900
 
+[evaluation]
+base_model_env = "BENCHFLOW_BASE_MODEL"
+student_model_env = "BENCHFLOW_ADAPTER_MODEL"
+base_url_env = "BENCHFLOW_PROVIDER_BASE_URL"
+api_key_env = "BENCHFLOW_PROVIDER_API_KEY"
+
 [teacher]
 enabled = true
 model = "glm/glm-5.1"

--- a/pipelines/benchflow-task-posttrain/configs/qwen3-4b-data-agent-smoke.toml
+++ b/pipelines/benchflow-task-posttrain/configs/qwen3-4b-data-agent-smoke.toml
@@ -34,6 +34,12 @@ sandbox_setup_timeout_sec = 300
 agent_idle_timeout_sec = 300
 agent_timeout_sec = 900
 
+[evaluation]
+base_model_env = "BENCHFLOW_BASE_MODEL"
+student_model_env = "BENCHFLOW_ADAPTER_MODEL"
+base_url_env = "BENCHFLOW_PROVIDER_BASE_URL"
+api_key_env = "BENCHFLOW_PROVIDER_API_KEY"
+
 [teacher]
 enabled = true
 model = "glm/glm-5.1"

--- a/pipelines/benchflow-task-posttrain/configs/qwen3-4b-hf-job-smoke.toml
+++ b/pipelines/benchflow-task-posttrain/configs/qwen3-4b-hf-job-smoke.toml
@@ -34,6 +34,12 @@ sandbox_setup_timeout_sec = 300
 agent_idle_timeout_sec = 300
 agent_timeout_sec = 900
 
+[evaluation]
+base_model_env = "BENCHFLOW_BASE_MODEL"
+student_model_env = "BENCHFLOW_ADAPTER_MODEL"
+base_url_env = "BENCHFLOW_PROVIDER_BASE_URL"
+api_key_env = "BENCHFLOW_PROVIDER_API_KEY"
+
 [teacher]
 enabled = true
 model = "glm/glm-5.1"

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/benchmarks.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/benchmarks.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from .config import PipelineConfig, load_config
+from .config import load_config
 from .io import CommandRunner, load_json, read_task_ids, write_json
 
 
@@ -75,11 +75,7 @@ def _snapshot_command(suite: BenchmarkSuite, destination: Path) -> list[str]:
     ]
     if suite.path:
         command.extend(["--path", suite.path])
-    command.extend(
-        item
-        for task_id in task_ids
-        for item in ("--include-task", task_id)
-    )
+    command.extend(item for task_id in task_ids for item in ("--include-task", task_id))
     return command
 
 
@@ -99,7 +95,7 @@ def run_benchmark_matrix(
     final_model = str(score.get("final_model") or run_dir / "checkpoints" / "grpo")
     runner = CommandRunner(cwd=config.source.parent, dry_run=dry_run)
     results: list[dict[str, Any]] = []
-    from .policy import evaluate
+    from .opencode import evaluate
 
     for suite in suites:
         task_ids = read_task_ids(suite.task_list)
@@ -112,47 +108,29 @@ def run_benchmark_matrix(
         )
         jobs_root = run_dir / "jobs" / "benchmarks" / suite.name
         results_root = run_dir / "results" / "benchmarks" / suite.name
-        if dry_run:
-            baseline_score = final_score = None
-            runner.commands.extend(
-                [
-                    {
-                        "name": f"baseline_benchmark_{suite.name}",
-                        "call": "policy.evaluate",
-                        "model": config.model,
-                        "task_ids": task_ids,
-                    },
-                    {
-                        "name": f"final_benchmark_{suite.name}",
-                        "call": "policy.evaluate",
-                        "model": final_model,
-                        "task_ids": task_ids,
-                    },
-                ]
-            )
-        else:
-            baseline = evaluate(
-                config=config,
-                model=config.model,
-                tasks_dir=tasks_dir,
-                task_ids=task_ids,
-                jobs_dir=jobs_root / "baseline",
-                output_dir=results_root / "baseline-trainer",
-                metrics_path=results_root / "baseline.json",
-                run_name=f"{run_dir.name}-{suite.name}-baseline",
-            )
-            final = evaluate(
-                config=config,
-                model=final_model,
-                tasks_dir=tasks_dir,
-                task_ids=task_ids,
-                jobs_dir=jobs_root / "final",
-                output_dir=results_root / "final-trainer",
-                metrics_path=results_root / "final.json",
-                run_name=f"{run_dir.name}-{suite.name}-final",
-            )
-            baseline_score = float(baseline["score"])
-            final_score = float(final["score"])
+        baseline = evaluate(
+            config=config,
+            runner=runner,
+            stage=f"baseline_benchmark_{suite.name}",
+            model=config.model,
+            tasks_dir=tasks_dir,
+            task_ids=task_ids,
+            jobs_dir=jobs_root / "baseline",
+            metrics_path=results_root / "baseline.json",
+        )
+        final = evaluate(
+            config=config,
+            runner=runner,
+            stage=f"final_benchmark_{suite.name}",
+            model=final_model,
+            tasks_dir=tasks_dir,
+            task_ids=task_ids,
+            jobs_dir=jobs_root / "final",
+            metrics_path=results_root / "final.json",
+        )
+        baseline_score = None if baseline["score"] is None else float(baseline["score"])
+        final_score = None if final["score"] is None else float(final["score"])
+        if not dry_run:
             runner.run(
                 f"compare_benchmark_{suite.name}",
                 [

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/cli.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/cli.py
@@ -162,7 +162,10 @@ def main(argv: list[str] | None = None) -> int:
                 "DAYTONA_API_KEY",
                 "GLM_API_KEY",
                 "GLM_BASE_URL",
-                "OPENAI_API_KEY",
+                "BENCHFLOW_BASE_MODEL",
+                "BENCHFLOW_ADAPTER_MODEL",
+                "BENCHFLOW_PROVIDER_BASE_URL",
+                "BENCHFLOW_PROVIDER_API_KEY",
                 "WANDB_API_KEY",
             ]
         )

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/config.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/config.py
@@ -70,6 +70,14 @@ class HarnessConfig:
 
 
 @dataclass(frozen=True)
+class EvaluationConfig:
+    base_model_env: str = "BENCHFLOW_BASE_MODEL"
+    student_model_env: str = "BENCHFLOW_ADAPTER_MODEL"
+    base_url_env: str = "BENCHFLOW_PROVIDER_BASE_URL"
+    api_key_env: str = "BENCHFLOW_PROVIDER_API_KEY"
+
+
+@dataclass(frozen=True)
 class TeacherConfig:
     enabled: bool = True
     model: str = "glm/glm-5.1"
@@ -117,6 +125,7 @@ class PipelineConfig:
     eval_dataset: DatasetConfig
     runtime: RuntimeConfig = field(default_factory=RuntimeConfig)
     harness: HarnessConfig = field(default_factory=HarnessConfig)
+    evaluation: EvaluationConfig = field(default_factory=EvaluationConfig)
     teacher: TeacherConfig = field(default_factory=TeacherConfig)
     sft: SftConfig = field(default_factory=SftConfig)
     grpo: GrpoConfig = field(default_factory=GrpoConfig)
@@ -150,6 +159,14 @@ class PipelineConfig:
             or not self.harness.reasoning_effort.strip()
         ):
             errors.append("harness.reasoning_effort must be a non-empty string")
+        for label, value in (
+            ("evaluation.base_model_env", self.evaluation.base_model_env),
+            ("evaluation.student_model_env", self.evaluation.student_model_env),
+            ("evaluation.base_url_env", self.evaluation.base_url_env),
+            ("evaluation.api_key_env", self.evaluation.api_key_env),
+        ):
+            if not isinstance(value, str) or not value.strip():
+                errors.append(f"{label} must be a non-empty string")
         if self.runtime.openenv_url and self.runtime.integration != "openenv":
             errors.append("runtime.openenv_url requires integration = openenv")
         if (
@@ -217,6 +234,7 @@ def load_config(path: str | Path) -> PipelineConfig:
     eval_data = _table(data, "eval_dataset")
     runtime = _table(data, "runtime")
     harness = _table(data, "harness", required=True)
+    evaluation = _table(data, "evaluation", required=True)
     teacher = _table(data, "teacher")
     sft = _table(data, "sft")
     grpo = _table(data, "grpo")
@@ -240,6 +258,7 @@ def load_config(path: str | Path) -> PipelineConfig:
         ),
         runtime=RuntimeConfig(**runtime),
         harness=HarnessConfig(**harness),
+        evaluation=EvaluationConfig(**evaluation),
         teacher=TeacherConfig(**teacher),
         sft=SftConfig(**sft),
         grpo=GrpoConfig(**grpo),

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/io.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/io.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import os
 import shlex
 import subprocess
 import sys
@@ -44,6 +45,14 @@ def write_json(path: Path, value: Any) -> None:
     path.write_text(json.dumps(value, indent=2, sort_keys=True, default=str) + "\n")
 
 
+def _resolved_command(command: list[str]) -> tuple[list[str], str | None]:
+    if command and command[0] == "bench":
+        bundled = Path(sys.executable).with_name("bench")
+        if bundled.is_file() and os.access(bundled, os.X_OK):
+            return [str(bundled), *command[1:]], str(bundled)
+    return command, None
+
+
 class CommandRunner:
     """Execute and record subprocess stages using argv, never shell strings."""
 
@@ -52,13 +61,22 @@ class CommandRunner:
         self.dry_run = dry_run
         self.commands: list[dict[str, Any]] = []
 
-    def run(self, name: str, command: list[str], *, check: bool = True) -> int:
+    def run(
+        self,
+        name: str,
+        command: list[str],
+        *,
+        check: bool = True,
+        env_overrides: dict[str, str] | None = None,
+    ) -> int:
         record = {
             "name": name,
             "cwd": str(self.cwd),
             "command": command,
             "shell": shlex.join(command),
         }
+        if env_overrides:
+            record["env_keys"] = sorted(env_overrides)
         self.commands.append(record)
         print(
             f"[posttrainarena] {name}: {record['shell']}",
@@ -68,7 +86,18 @@ class CommandRunner:
         if self.dry_run:
             record["returncode"] = 0
             return 0
-        result = subprocess.run(command, cwd=self.cwd, check=False)
+        env = None
+        if env_overrides:
+            env = {**os.environ, **env_overrides}
+        executable_command, resolved_executable = _resolved_command(command)
+        if resolved_executable:
+            record["resolved_executable"] = resolved_executable
+        result = subprocess.run(
+            executable_command,
+            cwd=self.cwd,
+            check=False,
+            env=env,
+        )
         record["returncode"] = result.returncode
         if check and result.returncode:
             raise subprocess.CalledProcessError(result.returncode, command)

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/opencode.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/opencode.py
@@ -1,0 +1,261 @@
+"""OpenCode evaluation through BenchFlow's production rollout CLI."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from pathlib import Path
+from typing import Any
+
+from .config import PipelineConfig
+from .io import CommandRunner, load_json, write_json
+
+
+def _environment_value(name: str, *, label: str, required: bool) -> str:
+    value = os.environ.get(name)
+    if value:
+        return value
+    if not required:
+        return f"${{{name}}}"
+    raise RuntimeError(f"Missing OpenCode {label}: {name}")
+
+
+def served_model(
+    config: PipelineConfig,
+    model: str,
+    *,
+    required: bool = True,
+) -> str:
+    env_name = (
+        config.evaluation.base_model_env
+        if model == config.model
+        else config.evaluation.student_model_env
+    )
+    resolved = _environment_value(
+        env_name,
+        label="served model",
+        required=required,
+    )
+    if required and "/" not in resolved:
+        raise RuntimeError(
+            f"OpenCode served model from {env_name} must use provider/model format"
+        )
+    return resolved
+
+
+def evaluation_env(
+    config: PipelineConfig,
+    *,
+    required: bool = True,
+) -> dict[str, str]:
+    return {
+        "BENCHFLOW_PROVIDER_BASE_URL": _environment_value(
+            config.evaluation.base_url_env,
+            label="evaluation endpoint",
+            required=required,
+        ),
+        "BENCHFLOW_PROVIDER_API_KEY": _environment_value(
+            config.evaluation.api_key_env,
+            label="evaluation API key",
+            required=required,
+        ),
+    }
+
+
+def build_evaluation_command(
+    *,
+    config: PipelineConfig,
+    model: str,
+    tasks_dir: Path,
+    task_ids: list[str],
+    jobs_dir: Path,
+    health_path: Path,
+    task_manifest_path: Path,
+    run_config_path: Path,
+    require_environment: bool = True,
+) -> list[str]:
+    if not task_ids:
+        raise ValueError("OpenCode evaluation requires at least one task")
+    command = [
+        "bench",
+        "eval",
+        "run",
+        "--tasks-dir",
+        str(tasks_dir),
+        "--agent",
+        config.harness.agent,
+        "--model",
+        served_model(config, model, required=require_environment),
+        "--sandbox",
+        config.sandbox,
+        "--skill-mode",
+        config.harness.skill_mode,
+        "--concurrency",
+        str(config.harness.concurrency),
+        "--usage-tracking",
+        config.harness.usage_tracking,
+        "--sandbox-setup-timeout",
+        str(config.harness.sandbox_setup_timeout_sec),
+        "--agent-idle-timeout",
+        str(config.harness.agent_idle_timeout_sec),
+        "--config-override",
+        json.dumps(
+            {"agent": {"timeout_sec": config.harness.agent_timeout_sec}},
+            separators=(",", ":"),
+        ),
+        "--expected-tasks",
+        str(len(task_ids)),
+        "--health-summary-out",
+        str(health_path),
+        "--task-manifest-out",
+        str(task_manifest_path),
+        "--run-config-out",
+        str(run_config_path),
+        "--jobs-dir",
+        str(jobs_dir),
+    ]
+    if config.runtime.sandbox_user is not None:
+        command.extend(["--sandbox-user", config.runtime.sandbox_user])
+    if config.harness.reasoning_effort:
+        command.extend(["--reasoning-effort", config.harness.reasoning_effort])
+    for task_id in task_ids:
+        command.extend(["--include", task_id])
+    return command
+
+
+def _ratio(summary: dict[str, Any], key: str) -> float:
+    value = summary.get(key)
+    if not isinstance(value, int | float) or isinstance(value, bool):
+        raise RuntimeError(f"OpenCode evaluation summary has no numeric {key}")
+    result = float(value)
+    if not math.isfinite(result) or not 0 <= result <= 1:
+        raise RuntimeError(f"OpenCode evaluation {key} is invalid: {value!r}")
+    return result
+
+
+def _count(summary: dict[str, Any], key: str) -> int:
+    value = summary.get(key)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise RuntimeError(f"OpenCode evaluation summary has no valid {key}")
+    return value
+
+
+def load_summary(
+    *,
+    jobs_dir: Path,
+    health_path: Path,
+    expected_tasks: int,
+) -> dict[str, Any]:
+    summary_path = jobs_dir / "summary.json"
+    summary = load_json(summary_path)
+    if _count(summary, "total") != expected_tasks:
+        raise RuntimeError(
+            f"OpenCode evaluation produced {summary.get('total')!r} tasks; "
+            f"expected {expected_tasks}"
+        )
+    if _count(summary, "errored") or _count(summary, "verifier_errored"):
+        raise RuntimeError("OpenCode evaluation contains agent or verifier errors")
+    if _ratio(summary, "telemetry_coverage") < 1.0:
+        raise RuntimeError("OpenCode evaluation telemetry coverage is incomplete")
+    health = load_json(health_path)
+    if _count(health, "total_rows") != expected_tasks:
+        raise RuntimeError(
+            f"OpenCode evaluation health summary has "
+            f"{health.get('total_rows')!r} rows; expected {expected_tasks}"
+        )
+    if _count(health, "scored_rows") != expected_tasks:
+        raise RuntimeError(
+            f"OpenCode evaluation health summary has "
+            f"scored_rows={health.get('scored_rows')!r}; expected {expected_tasks}"
+        )
+    for key in (
+        "unscored_rows",
+        "zero_tool_rows",
+        "missing_llm_trajectory",
+        "malformed_llm_trajectory",
+    ):
+        value = _count(health, key)
+        if value != 0:
+            raise RuntimeError(
+                f"OpenCode evaluation health summary has {key}={value!r}"
+            )
+    score_key = (
+        "score_excl_errors_ratio"
+        if "score_excl_errors_ratio" in summary
+        else "score_ratio"
+    )
+    return {
+        "score": _ratio(summary, score_key),
+        "summary": summary,
+        "summary_path": str(summary_path),
+        "health": health,
+        "health_path": str(health_path),
+    }
+
+
+def evaluate(
+    *,
+    config: PipelineConfig,
+    runner: CommandRunner,
+    stage: str,
+    model: str,
+    tasks_dir: Path,
+    task_ids: list[str],
+    jobs_dir: Path,
+    metrics_path: Path,
+) -> dict[str, Any]:
+    require_environment = not runner.dry_run
+    health_path = metrics_path.with_name(f"{metrics_path.stem}_health.json")
+    task_manifest_path = metrics_path.with_name(
+        f"{metrics_path.stem}_task_manifest.json"
+    )
+    run_config_path = metrics_path.with_name(f"{metrics_path.stem}_run_config.json")
+    runner.run(
+        stage,
+        build_evaluation_command(
+            config=config,
+            model=model,
+            tasks_dir=tasks_dir,
+            task_ids=task_ids,
+            jobs_dir=jobs_dir,
+            health_path=health_path,
+            task_manifest_path=task_manifest_path,
+            run_config_path=run_config_path,
+            require_environment=require_environment,
+        ),
+        env_overrides=evaluation_env(config, required=require_environment),
+    )
+    if runner.dry_run:
+        return {
+            "mode": "eval",
+            "harness": config.harness.agent,
+            "model": model,
+            "served_model": served_model(config, model, required=False),
+            "task_ids": task_ids,
+            "task_count": len(task_ids),
+            "score": None,
+            "jobs_dir": str(jobs_dir),
+        }
+    loaded = load_summary(
+        jobs_dir=jobs_dir,
+        health_path=health_path,
+        expected_tasks=len(task_ids),
+    )
+    payload = {
+        "mode": "eval",
+        "harness": config.harness.agent,
+        "model": model,
+        "served_model": served_model(config, model),
+        "task_ids": task_ids,
+        "task_count": len(task_ids),
+        "score": loaded["score"],
+        "summary": loaded["summary"],
+        "health": loaded["health"],
+        "jobs_dir": str(jobs_dir),
+        "health_path": str(health_path),
+        "task_manifest_path": str(task_manifest_path),
+        "run_config_path": str(run_config_path),
+    }
+    write_json(metrics_path, payload)
+    return payload

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/pipeline.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/pipeline.py
@@ -63,9 +63,10 @@ class Pipeline:
             "eval_task_count": len(self.eval_task_ids),
             "runtime": asdict(self.config.runtime),
             "harness": asdict(self.config.harness),
+            "evaluation": asdict(self.config.evaluation),
             "harness_migration": {
-                "applied_stages": ["teacher"],
-                "pending_stages": ["evaluation", "grpo"],
+                "applied_stages": ["teacher", "evaluation"],
+                "pending_stages": ["grpo"],
             },
             "teacher": asdict(self.config.teacher),
             "sft": asdict(self.config.sft),
@@ -239,31 +240,20 @@ class Pipeline:
     ) -> float | None:
         if self.resume and metrics_path.is_file():
             return load_score(metrics_path)
-        if self.dry_run:
-            self.runner.commands.append(
-                {
-                    "name": stage,
-                    "call": "policy.evaluate",
-                    "model": model,
-                    "task_ids": task_ids,
-                    "jobs_dir": str(jobs_dir),
-                    "metrics_path": str(metrics_path),
-                }
-            )
-            return None
-        from .policy import evaluate
+        from .opencode import evaluate
 
         payload = evaluate(
             config=self.config,
+            runner=self.runner,
+            stage=stage,
             model=model,
             tasks_dir=tasks_dir,
             task_ids=task_ids,
             jobs_dir=jobs_dir,
-            output_dir=self.layout.results / f"{stage}_trainer",
             metrics_path=metrics_path,
-            run_name=f"{self.run_name}-{stage}",
         )
-        return float(payload["score"])
+        score = payload["score"]
+        return None if score is None else float(score)
 
     def _collect_and_convert_teacher_data(self) -> None:
         manifest_path = self.layout.reports / "teacher_manifest.json"
@@ -408,9 +398,10 @@ class Pipeline:
             "grpo_planned": grpo_planned,
             "grpo_ran": grpo_ran,
             "harness": asdict(self.config.harness),
+            "evaluation": asdict(self.config.evaluation),
             "harness_migration": {
-                "applied_stages": ["teacher"],
-                "pending_stages": ["evaluation", "grpo"],
+                "applied_stages": ["teacher", "evaluation"],
+                "pending_stages": ["grpo"],
             },
             "benchflow_commit": BENCHFLOW_COMMIT,
             "train_dataset": asdict(self.config.train_dataset),

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/policy.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/policy.py
@@ -1,8 +1,7 @@
-"""BenchFlow-backed policy evaluation and GRPO training."""
+"""Legacy TRL environment integration retained only for GRPO training."""
 
 from __future__ import annotations
 
-import math
 from pathlib import Path
 from typing import Any
 
@@ -42,79 +41,6 @@ def _model_init_kwargs(config: PipelineConfig, model: str) -> dict[str, Any]:
     if model == config.model and config.model_revision:
         values["revision"] = config.model_revision
     return values
-
-
-def evaluate(
-    *,
-    config: PipelineConfig,
-    model: str,
-    tasks_dir: Path,
-    task_ids: list[str],
-    jobs_dir: Path,
-    output_dir: Path,
-    metrics_path: Path,
-    run_name: str,
-) -> dict[str, Any]:
-    from trl import GRPOConfig, GRPOTrainer
-
-    integration = build_environment_integration(
-        config=config,
-        tasks_dir=tasks_dir,
-        task_ids=task_ids,
-        jobs_dir=jobs_dir,
-        reset_message=RESET_MESSAGE,
-    )
-    rows = list(integration.train_dataset_rows)
-    try:
-        dataset = integration.train_dataset
-        eval_batch_size = len(rows)
-        generation_batch_size = math.lcm(
-            eval_batch_size, config.runtime.num_generations
-        )
-        values = {
-            **_common(config, output_dir, run_name),
-            "do_eval": True,
-            "per_device_train_batch_size": config.runtime.num_generations,
-            "per_device_eval_batch_size": eval_batch_size,
-            "generation_batch_size": generation_batch_size,
-            "num_generations": config.runtime.num_generations,
-            "num_generations_eval": 1,
-        }
-        values["model_init_kwargs"] = _model_init_kwargs(config, model)
-        trainer = GRPOTrainer(
-            model=model,
-            args=GRPOConfig(**supported_kwargs(GRPOConfig, values)),
-            train_dataset=dataset.select(range(1)),
-            eval_dataset=dataset,
-            environment_factory=integration.environment_factory,
-            reward_funcs=list(integration.reward_funcs),
-        )
-        metrics = trainer.evaluate()
-    finally:
-        integration.close()
-    score = next(
-        (
-            value
-            for key, value in metrics.items()
-            if key.startswith("eval_rewards/") and key.endswith("/mean")
-        ),
-        None,
-    )
-    if not isinstance(score, int | float):
-        score = metrics.get("eval_reward")
-    if not isinstance(score, int | float):
-        raise RuntimeError(f"Evaluation metrics contain no BenchFlow reward: {metrics}")
-    payload = {
-        "mode": "eval",
-        "model": model,
-        "task_ids": [row["benchflow_task_id"] for row in rows],
-        "task_count": len(rows),
-        "score": float(score),
-        "metrics": metrics,
-        "jobs_dir": str(jobs_dir),
-    }
-    write_json(metrics_path, payload)
-    return payload
 
 
 def train_grpo(

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/publishing.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/publishing.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 from pathlib import Path
 from typing import Any
@@ -16,7 +15,10 @@ SECRET_ENV_NAMES = (
     "DAYTONA_API_KEY",
     "GLM_API_KEY",
     "GLM_BASE_URL",
-    "OPENAI_API_KEY",
+    "BENCHFLOW_BASE_MODEL",
+    "BENCHFLOW_ADAPTER_MODEL",
+    "BENCHFLOW_PROVIDER_BASE_URL",
+    "BENCHFLOW_PROVIDER_API_KEY",
     "WANDB_API_KEY",
 )
 
@@ -45,9 +47,7 @@ def build_run_record(
     score_path = run_dir / "reports" / "score.json"
     score = load_json(score_path) if score_path.is_file() else {}
     benchmark_path = run_dir / "reports" / "benchmarks" / "summary.json"
-    benchmark_summary = (
-        load_json(benchmark_path) if benchmark_path.is_file() else None
-    )
+    benchmark_summary = load_json(benchmark_path) if benchmark_path.is_file() else None
     return {
         "schema_version": 1,
         "run_id": run_id,
@@ -62,9 +62,7 @@ def build_run_record(
         "score_after_posttrain": score.get("score_after_posttrain"),
         "delta_score": score.get("delta_score"),
         "macro_benchmark_delta": (
-            benchmark_summary.get("macro_delta_score")
-            if benchmark_summary
-            else None
+            benchmark_summary.get("macro_delta_score") if benchmark_summary else None
         ),
         "benchmark_scores": (
             benchmark_summary.get("benchmarks") if benchmark_summary else []

--- a/pipelines/benchflow-task-posttrain/tests/test_benchmarks.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_benchmarks.py
@@ -44,6 +44,10 @@ def test_benchmark_manifest_and_dry_run_matrix(tmp_path: Path) -> None:
     assert result["macro_delta_score"] is None
     assert result["benchmarks"][0]["task_ids"] == ["0000_369_369503_qa_1"]
     assert len(result["commands"]) == 3
+    for command in result["commands"][1:]:
+        assert command["command"][command["command"].index("--agent") + 1] == (
+            "opencode"
+        )
 
 
 def test_checked_in_multi_benchmark_manifest_is_cross_domain() -> None:

--- a/pipelines/benchflow-task-posttrain/tests/test_config.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_config.py
@@ -21,6 +21,10 @@ def test_example_config_is_valid_and_pinned() -> None:
     assert len(config.eval_dataset.revision) == 40
     assert config.harness.agent == "opencode"
     assert config.harness.usage_tracking == "required"
+    assert config.evaluation.base_model_env == "BENCHFLOW_BASE_MODEL"
+    assert config.evaluation.student_model_env == "BENCHFLOW_ADAPTER_MODEL"
+    assert config.evaluation.base_url_env == "BENCHFLOW_PROVIDER_BASE_URL"
+    assert config.evaluation.api_key_env == "BENCHFLOW_PROVIDER_API_KEY"
     assert config.teacher.model == "glm/glm-5.1"
     assert config.teacher.min_reward == 1.0
     assert config.teacher.min_verified == 15
@@ -71,6 +75,30 @@ def test_config_rejects_non_opencode_harness() -> None:
     config = replace(config, harness=replace(config.harness, agent="openhands"))
 
     with pytest.raises(ValueError, match="harness.agent must be opencode"):
+        config.validate()
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("base_model_env", "", "evaluation.base_model_env"),
+        ("student_model_env", "", "evaluation.student_model_env"),
+        ("base_url_env", "", "evaluation.base_url_env"),
+        ("api_key_env", "", "evaluation.api_key_env"),
+    ],
+)
+def test_config_rejects_invalid_evaluation_values(
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    config = replace(
+        config,
+        evaluation=replace(config.evaluation, **{field: value}),  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(ValueError, match=message):
         config.validate()
 
 
@@ -195,6 +223,24 @@ def test_config_rejects_non_table_harness(tmp_path: Path) -> None:
         load_config(config_path)
 
 
+def test_config_requires_evaluation_table(tmp_path: Path) -> None:
+    source = ROOT / "configs/qwen3-4b-data-agent-smoke.toml"
+    text = source.read_text()
+    evaluation_start = text.index("[evaluation]")
+    teacher_start = text.index("[teacher]")
+    task_lists = tmp_path / "task-lists"
+    task_lists.mkdir()
+    for name in ("data-agent-train-15.txt", "data-agent-eval-2.txt"):
+        (task_lists / name).write_text((ROOT / "task-lists" / name).read_text())
+    configs = tmp_path / "configs"
+    configs.mkdir()
+    config_path = configs / "missing-evaluation.toml"
+    config_path.write_text(text[:evaluation_start] + text[teacher_start:])
+
+    with pytest.raises(ValueError, match=r"Missing required \[evaluation\] table"):
+        load_config(config_path)
+
+
 def test_config_accepts_non_default_opencode_harness_values() -> None:
     config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
     config = replace(
@@ -250,6 +296,7 @@ revision = "def"
 task_list = "missing-eval.txt"
 [harness]
 agent = "opencode"
+[evaluation]
 """
     )
 

--- a/pipelines/benchflow-task-posttrain/tests/test_io.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_io.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -53,3 +54,55 @@ def test_command_runner_dry_run_returns_success_without_subprocess(
 
     assert runner.run("dry", ["bench", "eval", "run"]) == 0
     assert runner.commands[0]["returncode"] == 0
+
+
+def test_command_runner_passes_env_overrides_without_recording_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = {}
+
+    def fake_run(*_args, **kwargs):
+        captured.update(kwargs.get("env") or {})
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    runner = CommandRunner(cwd=tmp_path)
+
+    runner.run(
+        "eval",
+        ["bench", "eval", "run"],
+        env_overrides={"SECRET_TOKEN": "secret-value"},
+    )
+
+    assert captured["SECRET_TOKEN"] == "secret-value"
+    assert runner.commands[0]["env_keys"] == ["SECRET_TOKEN"]
+    assert "secret-value" not in str(runner.commands[0])
+
+
+def test_command_runner_prefers_bench_next_to_active_python(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    python = bin_dir / "python"
+    bench = bin_dir / "bench"
+    python.touch()
+    bench.touch()
+    bench.chmod(0o755)
+    captured: dict[str, object] = {}
+
+    def fake_run(command, **_kwargs):
+        captured["command"] = command
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(sys, "executable", str(python))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    runner = CommandRunner(cwd=tmp_path)
+
+    runner.run("eval", ["bench", "eval", "run"])
+
+    assert captured["command"] == [str(bench), "eval", "run"]
+    assert runner.commands[0]["command"] == ["bench", "eval", "run"]
+    assert runner.commands[0]["resolved_executable"] == str(bench)

--- a/pipelines/benchflow-task-posttrain/tests/test_opencode.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_opencode.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from posttrainarena.benchflow_pipeline.config import load_config
+from posttrainarena.benchflow_pipeline.io import CommandRunner
+from posttrainarena.benchflow_pipeline.opencode import (
+    build_evaluation_command,
+    evaluate,
+    evaluation_env,
+    load_summary,
+    served_model,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(autouse=True)
+def _served_endpoint_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BENCHFLOW_BASE_MODEL", "vllm/base")
+    monkeypatch.setenv("BENCHFLOW_ADAPTER_MODEL", "vllm/student")
+    monkeypatch.setenv(
+        "BENCHFLOW_PROVIDER_BASE_URL",
+        "https://example.invalid/v1",
+    )
+    monkeypatch.setenv("BENCHFLOW_PROVIDER_API_KEY", "secret")
+
+
+class FakeRunner(CommandRunner):
+    def __init__(self, cwd: Path, *, dry_run: bool = False) -> None:
+        super().__init__(cwd=cwd, dry_run=dry_run)
+
+    def run(
+        self,
+        name: str,
+        command: list[str],
+        *,
+        check: bool = True,
+        env_overrides: dict[str, str] | None = None,
+    ) -> int:
+        self.commands.append(
+            {
+                "name": name,
+                "command": command,
+                "env_keys": sorted(env_overrides or {}),
+            }
+        )
+        return 0
+
+
+def _config():
+    return load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+
+
+def _write_health(path: Path, **patch: Any) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "total_rows": 1,
+                "scored_rows": 1,
+                "unscored_rows": 0,
+                "rows_with_tool_calls": 1,
+                "zero_tool_rows": 0,
+                "missing_llm_trajectory": 0,
+                "malformed_llm_trajectory": 0,
+                **patch,
+            }
+        )
+    )
+
+
+def test_served_model_distinguishes_base_and_trained_checkpoint() -> None:
+    config = _config()
+
+    assert served_model(config, config.model) == "vllm/base"
+    assert served_model(config, "/tmp/sft") == "vllm/student"
+
+
+def test_served_model_requires_provider_qualified_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BENCHFLOW_BASE_MODEL", "bare-model")
+
+    with pytest.raises(RuntimeError, match="provider/model format"):
+        served_model(_config(), _config().model)
+
+
+def test_evaluation_env_maps_named_secrets_without_exposing_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config()
+    config = replace(
+        config,
+        evaluation=replace(
+            config.evaluation,
+            base_url_env="TEST_MODEL_URL",
+            api_key_env="TEST_MODEL_KEY",
+        ),
+    )
+    monkeypatch.setenv("TEST_MODEL_URL", "https://example.invalid/v1")
+    monkeypatch.setenv("TEST_MODEL_KEY", "secret")
+
+    assert evaluation_env(config) == {
+        "BENCHFLOW_PROVIDER_BASE_URL": "https://example.invalid/v1",
+        "BENCHFLOW_PROVIDER_API_KEY": "secret",
+    }
+
+
+def test_evaluation_env_fails_closed_on_missing_value() -> None:
+    config = _config()
+    config = replace(
+        config,
+        evaluation=replace(config.evaluation, base_url_env="MISSING_MODEL_URL"),
+    )
+
+    with pytest.raises(RuntimeError, match="MISSING_MODEL_URL"):
+        evaluation_env(config)
+
+
+def test_build_evaluation_command_uses_opencode_contract(tmp_path: Path) -> None:
+    config = _config()
+    command = build_evaluation_command(
+        config=config,
+        model=config.model,
+        tasks_dir=tmp_path / "tasks",
+        task_ids=["task-a", "task-b"],
+        jobs_dir=tmp_path / "jobs",
+        health_path=tmp_path / "health.json",
+        task_manifest_path=tmp_path / "task-manifest.json",
+        run_config_path=tmp_path / "run-config.json",
+    )
+
+    assert command[command.index("--agent") + 1] == "opencode"
+    assert command[command.index("--model") + 1] == "vllm/base"
+    assert command[command.index("--usage-tracking") + 1] == "required"
+    assert command[command.index("--expected-tasks") + 1] == "2"
+    assert command.count("--include") == 2
+
+
+@pytest.mark.parametrize(
+    ("patch", "message"),
+    [
+        ({"total": 2}, "expected 1"),
+        ({"errored": 1}, "agent or verifier errors"),
+        ({"verifier_errored": 1}, "agent or verifier errors"),
+        ({"telemetry_coverage": 0.5}, "telemetry coverage is incomplete"),
+        ({"telemetry_coverage": float("nan")}, "telemetry_coverage is invalid"),
+        ({"score_excl_errors_ratio": 1.1}, "score_excl_errors_ratio is invalid"),
+    ],
+)
+def test_load_summary_fails_closed(
+    tmp_path: Path,
+    patch: dict[str, Any],
+    message: str,
+) -> None:
+    jobs_dir = tmp_path / "jobs"
+    jobs_dir.mkdir()
+    summary = {
+        "total": 1,
+        "errored": 0,
+        "verifier_errored": 0,
+        "telemetry_coverage": 1.0,
+        "score_excl_errors_ratio": 1.0,
+        **patch,
+    }
+    (jobs_dir / "summary.json").write_text(json.dumps(summary))
+    health_path = tmp_path / "health.json"
+    _write_health(health_path)
+
+    with pytest.raises(RuntimeError, match=message):
+        load_summary(
+            jobs_dir=jobs_dir,
+            health_path=health_path,
+            expected_tasks=1,
+        )
+
+
+@pytest.mark.parametrize(
+    ("patch", "message"),
+    [
+        ({"total_rows": 2}, "expected 1"),
+        ({"scored_rows": 0}, "scored_rows=0"),
+        ({"unscored_rows": 1}, "unscored_rows=1"),
+        ({"zero_tool_rows": 1}, "zero_tool_rows=1"),
+        ({"missing_llm_trajectory": 1}, "missing_llm_trajectory=1"),
+        ({"malformed_llm_trajectory": 1}, "malformed_llm_trajectory=1"),
+    ],
+)
+def test_load_summary_rejects_unhealthy_artifacts(
+    tmp_path: Path,
+    patch: dict[str, Any],
+    message: str,
+) -> None:
+    jobs_dir = tmp_path / "jobs"
+    jobs_dir.mkdir()
+    (jobs_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "total": 1,
+                "errored": 0,
+                "verifier_errored": 0,
+                "telemetry_coverage": 1.0,
+                "score_excl_errors_ratio": 1.0,
+            }
+        )
+    )
+    health_path = tmp_path / "health.json"
+    _write_health(health_path, **patch)
+
+    with pytest.raises(RuntimeError, match=message):
+        load_summary(
+            jobs_dir=jobs_dir,
+            health_path=health_path,
+            expected_tasks=1,
+        )
+
+
+def test_evaluate_dry_run_records_only_environment_key_names(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name in (
+        "BENCHFLOW_BASE_MODEL",
+        "BENCHFLOW_ADAPTER_MODEL",
+        "BENCHFLOW_PROVIDER_BASE_URL",
+        "BENCHFLOW_PROVIDER_API_KEY",
+    ):
+        monkeypatch.delenv(name)
+    config = _config()
+    runner = FakeRunner(ROOT, dry_run=True)
+
+    payload = evaluate(
+        config=config,
+        runner=runner,
+        stage="baseline_eval",
+        model=config.model,
+        tasks_dir=tmp_path / "tasks",
+        task_ids=["task-a"],
+        jobs_dir=tmp_path / "jobs",
+        metrics_path=tmp_path / "metrics.json",
+    )
+
+    assert payload["served_model"] == "${BENCHFLOW_BASE_MODEL}"
+    assert payload["score"] is None
+    assert runner.commands[0]["env_keys"] == [
+        "BENCHFLOW_PROVIDER_API_KEY",
+        "BENCHFLOW_PROVIDER_BASE_URL",
+    ]
+
+
+def test_evaluate_writes_metrics_from_healthy_summary(tmp_path: Path) -> None:
+    config = _config()
+    jobs_dir = tmp_path / "jobs"
+    jobs_dir.mkdir()
+    (jobs_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "total": 1,
+                "errored": 0,
+                "verifier_errored": 0,
+                "telemetry_coverage": 1.0,
+                "score_excl_errors_ratio": 0.5,
+            }
+        )
+    )
+    runner = FakeRunner(ROOT)
+    metrics_path = tmp_path / "metrics.json"
+    _write_health(tmp_path / "metrics_health.json")
+
+    payload = evaluate(
+        config=config,
+        runner=runner,
+        stage="sft_eval",
+        model="/tmp/sft",
+        tasks_dir=tmp_path / "tasks",
+        task_ids=["task-a"],
+        jobs_dir=jobs_dir,
+        metrics_path=metrics_path,
+    )
+
+    assert payload["score"] == 0.5
+    assert payload["served_model"] == "vllm/student"
+    assert json.loads(metrics_path.read_text())["harness"] == "opencode"

--- a/pipelines/benchflow-task-posttrain/tests/test_pipeline.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_pipeline.py
@@ -30,9 +30,15 @@ def test_plan_exposes_public_stage_contract(tmp_path: Path) -> None:
         "agent_timeout_sec": 900,
         "reasoning_effort": None,
     }
+    assert plan["evaluation"] == {
+        "base_model_env": "BENCHFLOW_BASE_MODEL",
+        "student_model_env": "BENCHFLOW_ADAPTER_MODEL",
+        "base_url_env": "BENCHFLOW_PROVIDER_BASE_URL",
+        "api_key_env": "BENCHFLOW_PROVIDER_API_KEY",
+    }
     assert plan["harness_migration"] == {
-        "applied_stages": ["teacher"],
-        "pending_stages": ["evaluation", "grpo"],
+        "applied_stages": ["teacher", "evaluation"],
+        "pending_stages": ["grpo"],
     }
     assert plan["stages"][0] == "snapshot_train_tasks"
     assert plan["stages"][-1] == "write_score_report"
@@ -51,7 +57,10 @@ def test_dry_run_writes_score_schema_without_heavy_dependencies(tmp_path: Path) 
     assert saved["grpo_planned"] is True
     assert saved["grpo_ran"] is False
     assert saved["harness"]["agent"] == "opencode"
-    assert saved["harness_migration"]["applied_stages"] == ["teacher"]
+    assert saved["harness_migration"]["applied_stages"] == [
+        "teacher",
+        "evaluation",
+    ]
     convert = next(
         item
         for item in saved["commands"]
@@ -68,6 +77,15 @@ def test_dry_run_writes_score_schema_without_heavy_dependencies(tmp_path: Path) 
         "grpo_gate_eval",
         "compare_eval_lift",
     }
+    evaluation_commands = [
+        item
+        for item in saved["commands"]
+        if item["name"] in {"baseline_eval", "sft_eval", "grpo_gate_eval"}
+    ]
+    assert all(
+        item["command"][item["command"].index("--agent") + 1] == "opencode"
+        for item in evaluation_commands
+    )
 
 
 def test_pipeline_rejects_train_eval_overlap(tmp_path: Path) -> None:
@@ -95,10 +113,15 @@ def test_rl_only_dry_run_uses_base_model(tmp_path: Path) -> None:
     result = Pipeline(config, run_name="rl-only", dry_run=True).run()
     grpo = next(item for item in result["commands"] if item["name"] == "train_grpo")
     gate = next(item for item in result["commands"] if item["name"] == "grpo_gate_eval")
+    gate_task_ids = [
+        gate["command"][index + 1]
+        for index, value in enumerate(gate["command"])
+        if value == "--include"
+    ]
 
     assert grpo["model"] == config.model
     assert (
-        gate["task_ids"]
+        gate_task_ids
         == Pipeline(config, run_name="task-list", dry_run=True).train_task_ids[
             : config.grpo.gate_task_count
         ]


### PR DESCRIPTION
## What changed

- route baseline, post-SFT, GRPO-gate, final, and benchmark-matrix evaluation through `bench eval run --agent opencode`
- remove the legacy TRL evaluation function while retaining the temporary GRPO environment loop
- require named base/student model and endpoint environment variables without persisting secret values
- fail closed on agent/verifier errors, incomplete telemetry, unscored rows, zero-tool rollouts, and missing or malformed LLM trajectories
- resolve the `bench` executable next to the active Python environment to prevent stale global CLI use
- update HF Job secret handoff and architecture/status documentation

## Why

Teacher collection already used OpenCode, but evaluation could still silently run through the legacy TRL `environment_factory` loop. That made teacher data, checkpoint selection, and final reporting use different agent harnesses.

## Validation

- `109 passed` for the package test suite
- Ruff check and format check pass for changed Python files
- Python compileall and bootstrap shell syntax pass
- public `validate`, `plan`, and full `run --dry-run` route every evaluation stage through OpenCode
- real SkillsBench `3d-scan-calc` canary on Daytona: score `1.0`, zero agent/verifier errors, telemetry coverage `1.0`, 13 tool calls, 1 healthy `results.jsonl` row, and 13 valid `llm_trajectory.jsonl` rows

## Boundary

The student endpoint must already serve the checkpoint under the configured student alias. Automatic policy-to-endpoint resynchronization remains in the next OpenCode GRPO slice.