### PR TITLE
[codex] Accept BatchEncoding in SFT tokenization

### DIFF
--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/sft.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/sft.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import gc
 import json
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -42,7 +43,7 @@ def load_trl_rows(path: Path) -> list[dict[str, Any]]:
 
 
 def _token_ids(value: Any) -> list[int]:
-    if isinstance(value, dict):
+    if isinstance(value, Mapping):
         value = value.get("input_ids")
     if hasattr(value, "tolist"):
         value = value.tolist()

--- a/pipelines/benchflow-task-posttrain/tests/test_sft.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_sft.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections import UserDict
 from importlib.machinery import ModuleSpec
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -12,12 +13,17 @@ import pytest
 from posttrainarena.benchflow_pipeline.config import load_config
 from posttrainarena.benchflow_pipeline.sft import (
     build_tokenized_sft_rows,
+    _token_ids,
     load_trl_rows,
     train_sft,
 )
 
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_token_ids_accepts_batch_encoding_mapping() -> None:
+    assert _token_ids(UserDict({"input_ids": [[1, 2, 3]]})) == [1, 2, 3]
 
 
 def test_load_trl_rows_preserves_tools_and_object_arguments(tmp_path: Path) -> None:


### PR DESCRIPTION
## What changed

- Accepts generic `Mapping` tokenizer outputs, including Transformers `BatchEncoding`, when building exact SFT `input_ids` and labels.
- Adds a regression test with a non-`dict` mapping.

## Why

The first live exact-label SFT restart failed before training because Qwen3.5's tokenizer returned `BatchEncoding`; the helper only recognized plain `dict`.

## Validation

- Targeted SFT tests passed.
- Ruff, formatting, and Python compilation passed.
- The corrected file was deployed to the active two-H100 run, which resumed from the preserved baseline and 16/16 teacher trajectories.
