### PR TITLE
[codex] Make OpenCode evaluation deterministic

### DIFF
--- a/docs/opencode-grpo.md
+++ b/docs/opencode-grpo.md
@@ -57,7 +57,10 @@ Qwen3.5's native `<function=...><parameter=...>` syntax, and emits
 OpenAI-compatible streaming responses. The 4,096-token per-call cap keeps the
 non-streaming TRL server response below OpenCode's idle window; the GRPO
 trajectory can still span multiple calls up to the recipe's aggregate
-completion-token limit. Because LiteLLM's stream aggregation
+completion-token limit. Requests without explicit logprob capture default to
+greedy `temperature=0` with `seed=0` so baseline/SFT/final pass rates are
+reproducible; GRPO logprob-capture requests retain stochastic sampling unless
+the caller explicitly overrides it. Because LiteLLM's stream aggregation
 does not retain choice-level logprobs, the bridge also keeps a bounded
 authenticated sidecar keyed by the OpenAI completion ID. The GRPO collector
 resolves the exact sampled token IDs/logprobs from that sidecar and writes

--- a/docs/training-pipeline.md
+++ b/docs/training-pipeline.md
@@ -251,6 +251,11 @@ action-token budget overflow. A scored zero-tool completion is retained as
 model behavior, usually with reward `0`; verified teacher selection still
 requires at least one tool call.
 
+Baseline, post-SFT, gate, and final evaluation default to greedy sampling with
+`seed=0`. GRPO rollout requests opt into sampled-token logprobs and remain
+stochastic, preserving within-group reward variance without making pass-rate
+comparisons depend on random decoding.
+
 The evaluator itself has a real SkillsBench + Daytona canary with score `1.0`,
 complete provider telemetry, and healthy `results.jsonl` and
 `llm_trajectory.jsonl` artifacts. See

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/model_bridge.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/model_bridge.py
@@ -225,6 +225,12 @@ def _trl_request(body: dict[str, Any], config: ModelBridgeConfig) -> dict[str, A
     extra_body = body.get("extra_body")
     if isinstance(extra_body, dict):
         generation_kwargs.update(extra_body)
+    capture_logprobs = body.get("logprobs") is True
+    if not capture_logprobs and body.get("seed") is None:
+        generation_kwargs["seed"] = 0
+    temperature = body.get("temperature")
+    if temperature is None:
+        temperature = 1.0 if capture_logprobs else 0.0
     requested_max_tokens = body.get("max_completion_tokens")
     if requested_max_tokens is None:
         requested_max_tokens = body.get("max_tokens")
@@ -237,7 +243,7 @@ def _trl_request(body: dict[str, Any], config: ModelBridgeConfig) -> dict[str, A
         "messages": [messages],
         "n": 1,
         "repetition_penalty": float(body.get("repetition_penalty", 1.0)),
-        "temperature": float(body.get("temperature", 1.0)),
+        "temperature": float(temperature),
         "top_p": float(body.get("top_p", 1.0)),
         "top_k": int(body.get("top_k", -1)),
         "min_p": float(body.get("min_p", 0.0)),

--- a/pipelines/benchflow-task-posttrain/tests/test_model_bridge.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_model_bridge.py
@@ -207,6 +207,8 @@ def test_model_bridge_serves_authenticated_streaming_tool_call() -> None:
     assert captured["payload"]["tools"] == request["tools"]
     assert captured["payload"]["logprobs"] == 0
     assert captured["payload"]["max_tokens"] == 32
+    assert captured["payload"]["temperature"] == 1.0
+    assert "seed" not in captured["payload"]["generation_kwargs"]
 
 
 def test_model_bridge_caps_tokens_per_call() -> None:
@@ -237,6 +239,8 @@ def test_model_bridge_caps_tokens_per_call() -> None:
 
     assert response.status_code == 200
     assert captured["payload"]["max_tokens"] == 64
+    assert captured["payload"]["temperature"] == 0.0
+    assert captured["payload"]["generation_kwargs"]["seed"] == 0
     assert (
         client.get(
             f"/v1/benchflow/logprobs/{response.json()['id']}",


### PR DESCRIPTION
## What changed

- Defaults baseline, post-SFT, gate, and final OpenCode requests to greedy `temperature=0` with `seed=0`.
- Keeps GRPO logprob-capture requests stochastic unless the caller explicitly supplies sampling parameters.
- Documents the separation between deterministic pass-rate evaluation and stochastic RL exploration.

## Why

The completed 16-train/14-eval run had zero GRPO loss and zero gradient on every step, and SFT/final policy attestation hashes were identical. Despite the unchanged policy, one held-out task flipped from pass to fail because all evaluation requests inherited the bridge's `temperature=1.0` default. That makes single-run pass-rate deltas noisy and can create false lift or false regression.

## Validation

- Model-bridge tests cover deterministic ordinary requests and stochastic logprob requests.
- Ruff, formatting, and Python compilation passed.
- The live run established the failure mode with unchanged policy identity and differing pass outcomes.
