### PR TITLE
[codex] Use fixed-seed sampling for evaluation

### DIFF
--- a/docs/opencode-grpo.md
+++ b/docs/opencode-grpo.md
@@ -58,9 +58,10 @@ OpenAI-compatible streaming responses. The 4,096-token per-call cap keeps the
 non-streaming TRL server response below OpenCode's idle window; the GRPO
 trajectory can still span multiple calls up to the recipe's aggregate
 completion-token limit. Requests without explicit logprob capture default to
-greedy `temperature=0` with `seed=0` so baseline/SFT/final pass rates are
-reproducible; GRPO logprob-capture requests retain stochastic sampling unless
-the caller explicitly overrides it. Because LiteLLM's stream aggregation
+`temperature=1.0` with `seed=0`, preserving Qwen3.5's tool-use behavior while
+making baseline/SFT/final decoding reproducible. GRPO logprob-capture requests
+use the same temperature without a forced seed unless the caller explicitly
+overrides it. Because LiteLLM's stream aggregation
 does not retain choice-level logprobs, the bridge also keeps a bounded
 authenticated sidecar keyed by the OpenAI completion ID. The GRPO collector
 resolves the exact sampled token IDs/logprobs from that sidecar and writes

--- a/docs/training-pipeline.md
+++ b/docs/training-pipeline.md
@@ -251,10 +251,13 @@ action-token budget overflow. A scored zero-tool completion is retained as
 model behavior, usually with reward `0`; verified teacher selection still
 requires at least one tool call.
 
-Baseline, post-SFT, gate, and final evaluation default to greedy sampling with
-`seed=0`. GRPO rollout requests opt into sampled-token logprobs and remain
-stochastic, preserving within-group reward variance without making pass-rate
-comparisons depend on random decoding.
+Baseline, post-SFT, gate, and final evaluation default to
+`temperature=1.0, seed=0`. The fixed seed makes evaluation reproducible while
+preserving Qwen3.5 tool use; lower-temperature and greedy decoding can stall
+before the first tool call. GRPO rollout requests opt into sampled-token
+logprobs and do not receive a forced seed, preserving within-group reward
+variance without making pass-rate comparisons depend on uncontrolled random
+decoding.
 
 The evaluator itself has a real SkillsBench + Daytona canary with score `1.0`,
 complete provider telemetry, and healthy `results.jsonl` and

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/model_bridge.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/model_bridge.py
@@ -230,7 +230,7 @@ def _trl_request(body: dict[str, Any], config: ModelBridgeConfig) -> dict[str, A
         generation_kwargs["seed"] = 0
     temperature = body.get("temperature")
     if temperature is None:
-        temperature = 1.0 if capture_logprobs else 0.0
+        temperature = 1.0
     requested_max_tokens = body.get("max_completion_tokens")
     if requested_max_tokens is None:
         requested_max_tokens = body.get("max_tokens")

--- a/pipelines/benchflow-task-posttrain/tests/test_model_bridge.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_model_bridge.py
@@ -239,7 +239,7 @@ def test_model_bridge_caps_tokens_per_call() -> None:
 
     assert response.status_code == 200
     assert captured["payload"]["max_tokens"] == 64
-    assert captured["payload"]["temperature"] == 0.0
+    assert captured["payload"]["temperature"] == 1.0
     assert captured["payload"]["generation_kwargs"]["seed"] == 0
     assert (
         client.get(


### PR DESCRIPTION
## What changed

- Uses `temperature=1.0, seed=0` for baseline, post-SFT, gate, and final OpenCode evaluation.
- Keeps GRPO logprob-capture requests stochastic by omitting the forced seed.

## Why

Fully greedy and low-temperature decoding were reproducible but caused Qwen3.5 to stall before its first tool call: four red-wine baseline tasks produced no ACP action for more than four minutes and were headed to idle timeout. The earlier `temperature=1.0` default produced tool calls but made pass-rate deltas noisy because it had no fixed seed.

Fixed-seed sampling at the model's working temperature keeps repeated evaluation deterministic while preserving tool-use behavior.

## Validation

- Model-bridge tests assert ordinary requests use `temperature=1.0, seed=0`.
- GRPO requests still default to stochastic `temperature=1.0` without a forced seed.
- Ruff, formatting, and Python compilation passed.
