### PR TITLE
Scope deterministic seed to OpenCode agent calls

### DIFF
--- a/docs/opencode-grpo.md
+++ b/docs/opencode-grpo.md
@@ -57,9 +57,10 @@ Qwen3.5's native `<function=...><parameter=...>` syntax, and emits
 OpenAI-compatible streaming responses. The 4,096-token per-call cap keeps the
 non-streaming TRL server response below OpenCode's idle window; the GRPO
 trajectory can still span multiple calls up to the recipe's aggregate
-completion-token limit. Requests without explicit logprob capture default to
-`temperature=1.0` with `seed=0`, preserving Qwen3.5's tool-use behavior while
-making baseline/SFT/final decoding reproducible. GRPO logprob-capture requests
+completion-token limit. Tool-bearing requests without explicit logprob capture
+default to `temperature=1.0` with `seed=0`, preserving Qwen3.5's tool-use
+behavior while making baseline/SFT/final agent decoding reproducible. OpenCode
+helper requests without tools are not seeded, and GRPO logprob-capture requests
 use the same temperature without a forced seed unless the caller explicitly
 overrides it. Because LiteLLM's stream aggregation
 does not retain choice-level logprobs, the bridge also keeps a bounded
@@ -137,6 +138,9 @@ weights and leaves the frozen visual weights unchanged.
 This removes the former TRL `environment_factory` agent loop. OpenEnv remains a
 standalone protocol compatibility service, but it is not part of teacher
 collection, evaluation, or GRPO rollout generation.
+The bridge short-circuits OpenCode's title-generator prompt to a fixed local
+title without a provider call, avoiding helper failures before the first tool
+action.
 
 ## Validation boundary
 

--- a/docs/training-pipeline.md
+++ b/docs/training-pipeline.md
@@ -214,6 +214,8 @@ Provider credential values are not written to the run plan or score report.
 BenchFlow removes upstream provider keys from the OpenCode environment and
 replaces them with a per-run LiteLLM proxy token. Do not pass raw provider keys
 through `--agent-env`; participant tasks must only see the scoped proxy route.
+The model bridge answers OpenCode's title-generator prompt locally with a fixed
+title, so that helper cannot consume model traffic or block task solving.
 
 ## Execute and resume
 
@@ -251,13 +253,13 @@ action-token budget overflow. A scored zero-tool completion is retained as
 model behavior, usually with reward `0`; verified teacher selection still
 requires at least one tool call.
 
-Baseline, post-SFT, gate, and final evaluation default to
-`temperature=1.0, seed=0`. The fixed seed makes evaluation reproducible while
-preserving Qwen3.5 tool use; lower-temperature and greedy decoding can stall
-before the first tool call. GRPO rollout requests opt into sampled-token
-logprobs and do not receive a forced seed, preserving within-group reward
-variance without making pass-rate comparisons depend on uncontrolled random
-decoding.
+Tool-bearing baseline, post-SFT, gate, and final agent requests default to
+`temperature=1.0, seed=0`. The fixed seed makes task behavior reproducible
+while preserving Qwen3.5 tool use; lower-temperature and greedy decoding can
+stall before the first tool call. OpenCode title/summary helpers are not seeded.
+GRPO rollout requests opt into sampled-token logprobs and do not receive a
+forced seed, preserving within-group reward variance without making pass-rate
+comparisons depend on uncontrolled random decoding.
 
 The evaluator itself has a real SkillsBench + Daytona canary with score `1.0`,
 complete provider telemetry, and healthy `results.jsonl` and

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/model_bridge.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/model_bridge.py
@@ -226,7 +226,7 @@ def _trl_request(body: dict[str, Any], config: ModelBridgeConfig) -> dict[str, A
     if isinstance(extra_body, dict):
         generation_kwargs.update(extra_body)
     capture_logprobs = body.get("logprobs") is True
-    if not capture_logprobs and body.get("seed") is None:
+    if not capture_logprobs and body.get("tools") and body.get("seed") is None:
         generation_kwargs["seed"] = 0
     temperature = body.get("temperature")
     if temperature is None:
@@ -277,6 +277,50 @@ def _streaming_response(payload: dict[str, Any]) -> Any:
         yield "data: [DONE]\n\n"
 
     return StreamingResponse(events(), media_type="text/event-stream")
+
+
+def _is_title_request(body: dict[str, Any]) -> bool:
+    messages = body.get("messages")
+    if body.get("tools") or not isinstance(messages, list) or len(messages) < 2:
+        return False
+    first = messages[0]
+    second = messages[1]
+    return (
+        isinstance(first, dict)
+        and first.get("role") == "system"
+        and isinstance(first.get("content"), str)
+        and first["content"].startswith("You are a title generator.")
+        and isinstance(second, dict)
+        and second.get("role") == "user"
+        and isinstance(second.get("content"), str)
+        and second["content"].startswith("Generate a title for this conversation:")
+    )
+
+
+def _title_response(*, model: str) -> dict[str, Any]:
+    content = "Data analysis task"
+    return {
+        "id": f"chatcmpl-{uuid4().hex}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": content,
+                },
+                "logprobs": {"content": []},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        },
+    }
 
 
 def create_model_bridge_app(
@@ -358,14 +402,18 @@ def create_model_bridge_app(
     ) -> Any:
         authorize(authorization)
         model = str(body.get("model") or config.tokenizer_id)
-        upstream = await chat_call(_trl_request(body, config))
-        translated = translate_trl_chat_response(
-            payload=upstream,
-            tokenizer=tokenizer,
-            model=model,
-        )
+        if _is_title_request(body):
+            upstream = None
+            translated = _title_response(model=model)
+        else:
+            upstream = await chat_call(_trl_request(body, config))
+            translated = translate_trl_chat_response(
+                payload=upstream,
+                tokenizer=tokenizer,
+                model=model,
+            )
         completion_id = str(translated["id"])
-        if body.get("logprobs") is True:
+        if body.get("logprobs") is True and upstream is not None:
             logprob_store[completion_id] = {
                 "id": completion_id,
                 "prompt_ids": upstream["prompt_ids"][0],

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/opencode.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/opencode.py
@@ -80,7 +80,7 @@ def opencode_config_env(config: PipelineConfig) -> str:
             "bash": {
                 **{pattern: "deny" for pattern in config.harness.deny_bash_patterns},
             },
-        }
+        },
     }
     return "OPENCODE_CONFIG_CONTENT=" + json.dumps(
         content,

--- a/pipelines/benchflow-task-posttrain/tests/test_model_bridge.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_model_bridge.py
@@ -211,6 +211,99 @@ def test_model_bridge_serves_authenticated_streaming_tool_call() -> None:
     assert "seed" not in captured["payload"]["generation_kwargs"]
 
 
+def test_model_bridge_short_circuits_title_helper_without_provider_call() -> None:
+    async def fail_chat(_payload: dict[str, Any]) -> dict[str, Any]:
+        raise AssertionError("title helper must not call the model")
+
+    app = create_model_bridge_app(
+        ModelBridgeConfig(
+            upstream_url="http://127.0.0.1:8000",
+            tokenizer_id="Qwen/Qwen3-4B",
+        ),
+        tokenizer=FakeTokenizer(),
+        chat_call=fail_chat,
+    )
+    response = TestClient(app).post(
+        "/v1/chat/completions",
+        json={
+            "model": "Qwen/Qwen3-4B",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a title generator. You output ONLY a thread title."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": "Generate a title for this conversation:\n",
+                },
+                {"role": "user", "content": "Analyze red wine quality."},
+            ],
+            "stream": True,
+            "logprobs": True,
+        },
+    )
+
+    assert response.status_code == 200
+    chunk = next(
+        json.loads(line.removeprefix("data: "))
+        for line in response.text.splitlines()
+        if line.startswith("data: ") and line != "data: [DONE]"
+    )
+    assert chunk["choices"][0]["delta"]["content"] == "Data analysis task"
+    assert chunk["choices"][0]["finish_reason"] == "stop"
+    assert (
+        TestClient(app)
+        .get(
+            f"/v1/benchflow/logprobs/{chunk['id']}",
+        )
+        .status_code
+        == 404
+    )
+
+
+def test_model_bridge_does_not_intercept_tool_bearing_title_prompt() -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_chat(payload: dict[str, Any]) -> dict[str, Any]:
+        captured["payload"] = payload
+        return _upstream("OK")
+
+    app = create_model_bridge_app(
+        ModelBridgeConfig(
+            upstream_url="http://127.0.0.1:8000",
+            tokenizer_id="Qwen/Qwen3-4B",
+        ),
+        tokenizer=FakeTokenizer(),
+        chat_call=fake_chat,
+    )
+    response = TestClient(app).post(
+        "/v1/chat/completions",
+        json={
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are a title generator.",
+                },
+                {
+                    "role": "user",
+                    "content": "Generate a title for this conversation:",
+                },
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {"name": "bash", "parameters": {"type": "object"}},
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured["payload"]["tools"]
+
+
 def test_model_bridge_caps_tokens_per_call() -> None:
     captured: dict[str, Any] = {}
 
@@ -240,13 +333,46 @@ def test_model_bridge_caps_tokens_per_call() -> None:
     assert response.status_code == 200
     assert captured["payload"]["max_tokens"] == 64
     assert captured["payload"]["temperature"] == 1.0
-    assert captured["payload"]["generation_kwargs"]["seed"] == 0
+    assert "seed" not in captured["payload"]["generation_kwargs"]
     assert (
         client.get(
             f"/v1/benchflow/logprobs/{response.json()['id']}",
         ).status_code
         == 404
     )
+
+
+def test_model_bridge_fixes_seed_for_tool_evaluation_only() -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_chat(payload: dict[str, Any]) -> dict[str, Any]:
+        captured["payload"] = payload
+        return _upstream("OK")
+
+    app = create_model_bridge_app(
+        ModelBridgeConfig(
+            upstream_url="http://127.0.0.1:8000",
+            tokenizer_id="Qwen/Qwen3-4B",
+        ),
+        tokenizer=FakeTokenizer(),
+        chat_call=fake_chat,
+    )
+    response = TestClient(app).post(
+        "/v1/chat/completions",
+        json={
+            "messages": [{"role": "user", "content": "inspect"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {"name": "bash", "parameters": {"type": "object"}},
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured["payload"]["temperature"] == 1.0
+    assert captured["payload"]["generation_kwargs"]["seed"] == 0
 
 
 def test_model_bridge_retains_eight_concurrent_sixty_five_turn_rollouts() -> None:


### PR DESCRIPTION
## What changed

- Applies the deterministic `seed=0` only to tool-bearing evaluation requests.
- Keeps GRPO sampled-logprob requests stochastic unless the caller supplies a seed.
- Removes the ineffective OpenCode `agent.title` / `agent.summary` disable config.
- Short-circuits the exact OpenCode title-generator request in the local model bridge with a fixed title and no provider call.
- Handles the real GRPO title shape with `stream=true, logprobs=true` without creating a model sidecar trace.
- Adds negative coverage so a tool-bearing task prompt cannot be mistaken for the title helper.

## Why

OpenCode sends a title-helper request before the task-solving request. Seeding every non-logprob request made that helper part of deterministic evaluation, and the attempted config disable was not honored by the installed OpenCode CLI. The helper could fail or stall before the first task tool action.

The bridge now answers only the recognizable OpenCode title prompt locally. Task-solving traffic still uses OpenCode end to end, while baseline/SFT/final agent calls remain reproducible and GRPO retains within-group sampling variance.

## Validation

- `211` package contract tests pass.
- Targeted model-bridge and OpenCode tests pass.
- Ruff check and format check pass.
- Python compilation and `git diff --check` pass.
- The full Qwen3.5 config validates and plans with the official 9B student, 397B teacher, one-epoch LoRA SFT, and always-run GRPO contract.
- Preserved real OpenCode trajectories confirm the title request starts with `You are a title generator.`, has no tools, and uses `logprobs=true` during GRPO.
- Preserved red-wine and videogamesales agent prompts produced tool calls across seeds `0,1,2,3,4,7,42,123,2026` at `temperature=1.0`.
