### PR TITLE
Normalize OpenCode tool arguments before Qwen rendering

### DIFF
--- a/docs/opencode-grpo.md
+++ b/docs/opencode-grpo.md
@@ -70,6 +70,11 @@ resolves the exact sampled token IDs/logprobs from that sidecar and writes
 at 16,384 generated tokens while the pipeline separately enforces the
 rollout-level completion budget.
 
+On follow-up turns, OpenCode sends function arguments as JSON strings while
+Qwen3.5's chat template expects mappings. The bridge normalizes those arguments
+before forwarding the conversation to TRL; GRPO prompt reconstruction uses the
+same normalization so served and trained token IDs stay aligned.
+
 ## Per-update lifecycle
 
 ```text

--- a/docs/training-pipeline.md
+++ b/docs/training-pipeline.md
@@ -216,6 +216,8 @@ replaces them with a per-run LiteLLM proxy token. Do not pass raw provider keys
 through `--agent-env`; participant tasks must only see the scoped proxy route.
 The model bridge answers OpenCode's title-generator prompt locally with a fixed
 title, so that helper cannot consume model traffic or block task solving.
+It also converts OpenCode's stringified follow-up tool arguments back to JSON
+objects before Qwen3.5 chat-template rendering.
 
 ## Execute and resume
 

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/grpo.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/grpo.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import copy
 import hashlib
 import json
 import math
@@ -16,6 +15,7 @@ from typing import Any, Sequence
 
 from .config import PipelineConfig
 from .io import CommandRunner, supported_kwargs, write_json
+from .model_bridge import normalize_tool_call_arguments
 from .opencode import ServedModelRole, evaluate, served_model
 
 
@@ -432,30 +432,7 @@ def _chat_prompt_ids(
     messages: list[dict[str, Any]],
     tools: list[dict[str, Any]] | None,
 ) -> list[int]:
-    normalized_messages = copy.deepcopy(messages)
-    for message in normalized_messages:
-        tool_calls = message.get("tool_calls")
-        if not isinstance(tool_calls, list):
-            continue
-        for tool_call in tool_calls:
-            function = (
-                tool_call.get("function") if isinstance(tool_call, dict) else None
-            )
-            if not isinstance(function, dict):
-                continue
-            arguments = function.get("arguments")
-            if isinstance(arguments, str):
-                try:
-                    parsed = json.loads(arguments)
-                except json.JSONDecodeError as exc:
-                    raise RuntimeError(
-                        "OpenCode tool-call arguments are not valid JSON"
-                    ) from exc
-                if not isinstance(parsed, dict):
-                    raise RuntimeError(
-                        "OpenCode tool-call arguments must decode to an object"
-                    )
-                function["arguments"] = parsed
+    normalized_messages = normalize_tool_call_arguments(messages)
     kwargs: dict[str, Any] = {
         "tokenize": True,
         "add_generation_prompt": True,

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/model_bridge.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/model_bridge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import re
 import time
@@ -99,6 +100,38 @@ def parse_qwen_tool_calls(text: str) -> tuple[str | None, list[dict[str, Any]]]:
         )
     remaining = TOOL_CALL_PATTERN.sub("", text).strip()
     return remaining or None, calls
+
+
+def normalize_tool_call_arguments(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Convert OpenAI string arguments to the mapping Qwen's template expects."""
+    normalized_messages = copy.deepcopy(messages)
+    for message in normalized_messages:
+        tool_calls = message.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for tool_call in tool_calls:
+            function = (
+                tool_call.get("function") if isinstance(tool_call, dict) else None
+            )
+            if not isinstance(function, dict):
+                continue
+            arguments = function.get("arguments")
+            if not isinstance(arguments, str):
+                continue
+            try:
+                parsed = json.loads(arguments)
+            except json.JSONDecodeError as exc:
+                raise RuntimeError(
+                    "OpenCode tool-call arguments are not valid JSON"
+                ) from exc
+            if not isinstance(parsed, dict):
+                raise RuntimeError(
+                    "OpenCode tool-call arguments must decode to an object"
+                )
+            function["arguments"] = parsed
+    return normalized_messages
 
 
 def _sampled_logprob_rows(
@@ -218,6 +251,8 @@ def _trl_request(body: dict[str, Any], config: ModelBridgeConfig) -> dict[str, A
     messages = body.get("messages")
     if not isinstance(messages, list) or not messages:
         raise ValueError("messages must be a non-empty list")
+    if any(not isinstance(message, dict) for message in messages):
+        raise ValueError("messages must contain objects")
     generation_kwargs = {}
     for key in ("stop", "seed", "frequency_penalty", "presence_penalty"):
         if body.get(key) is not None:
@@ -240,7 +275,7 @@ def _trl_request(body: dict[str, Any], config: ModelBridgeConfig) -> dict[str, A
         else min(int(requested_max_tokens), config.max_tokens_per_call)
     )
     return {
-        "messages": [messages],
+        "messages": [normalize_tool_call_arguments(messages)],
         "n": 1,
         "repetition_penalty": float(body.get("repetition_penalty", 1.0)),
         "temperature": float(temperature),

--- a/pipelines/benchflow-task-posttrain/tests/test_model_bridge.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_model_bridge.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 from posttrainarena.benchflow_pipeline.model_bridge import (
     ModelBridgeConfig,
     create_model_bridge_app,
+    normalize_tool_call_arguments,
     parse_qwen_tool_calls,
     translate_trl_chat_response,
 )
@@ -84,6 +85,61 @@ unexpected
 </tool_call>
 """
         )
+
+
+def test_normalize_tool_call_arguments_for_qwen_chat_template() -> None:
+    messages = [
+        {"role": "user", "content": "inspect"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "arguments": '{"filePath":"/home/user/input/data.csv"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-1",
+            "content": "a,b\n1,2",
+        },
+    ]
+
+    normalized = normalize_tool_call_arguments(messages)
+
+    assert normalized[1]["tool_calls"][0]["function"]["arguments"] == {
+        "filePath": "/home/user/input/data.csv"
+    }
+    assert messages[1]["tool_calls"][0]["function"]["arguments"] == (
+        '{"filePath":"/home/user/input/data.csv"}'
+    )
+
+
+@pytest.mark.parametrize("arguments", ["not-json", "[]"])
+def test_normalize_tool_call_arguments_rejects_invalid_values(arguments: str) -> None:
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "arguments": arguments,
+                    },
+                }
+            ],
+        }
+    ]
+
+    with pytest.raises(RuntimeError, match="arguments"):
+        normalize_tool_call_arguments(messages)
 
 
 def test_translate_trl_chat_response_preserves_token_ids_and_logprobs() -> None:
@@ -302,6 +358,56 @@ def test_model_bridge_does_not_intercept_tool_bearing_title_prompt() -> None:
 
     assert response.status_code == 200
     assert captured["payload"]["tools"]
+
+
+def test_model_bridge_normalizes_followup_tool_arguments_for_trl() -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_chat(payload: dict[str, Any]) -> dict[str, Any]:
+        captured["payload"] = payload
+        return _upstream("OK")
+
+    app = create_model_bridge_app(
+        ModelBridgeConfig(
+            upstream_url="http://127.0.0.1:8000",
+            tokenizer_id="Qwen/Qwen3-4B",
+        ),
+        tokenizer=FakeTokenizer(),
+        chat_call=fake_chat,
+    )
+    response = TestClient(app).post(
+        "/v1/chat/completions",
+        json={
+            "messages": [
+                {"role": "user", "content": "inspect"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": '{"filePath":"/tmp/data.csv"}',
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call-1",
+                    "content": "a,b\n1,2",
+                },
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    arguments = captured["payload"]["messages"][0][1]["tool_calls"][0]["function"][
+        "arguments"
+    ]
+    assert arguments == {"filePath": "/tmp/data.csv"}
 
 
 def test_model_bridge_caps_tokens_per_call() -> None:


### PR DESCRIPTION
## What changed

- Normalizes OpenAI-compatible stringified `tool_calls[].function.arguments` into JSON objects before forwarding follow-up conversations to the TRL vLLM server.
- Reuses the same normalization for GRPO prompt-ID reconstruction, eliminating duplicate logic and keeping served/trained tokenization aligned.
- Fails closed on malformed or non-object tool arguments.
- Documents the OpenCode-to-Qwen follow-up conversion.

## Why

A live red-wine OpenCode canary reached and completed its first tool call, then the TRL server hung while rendering the second model turn. Replaying the exact captured four-message follow-up through the official Qwen3.5 tokenizer reproduced the root cause immediately:

`TypeError: Can only get item pairs from a mapping.`

OpenCode correctly emits OpenAI chat-completions messages with function arguments serialized as JSON strings. Qwen3.5's chat template iterates those arguments as a mapping. GRPO's offline token reconstruction already converted the string to an object, but the live bridge did not.

A fake TRL backend using the same BenchFlow + OpenCode harness completed both turns, proving the agent loop and tool execution were healthy and isolating the failure to live Qwen chat-template rendering.

## Validation

- `215` package contract tests pass.
- `39` focused model-bridge and GRPO tests pass.
- Ruff check/format, Python compilation, and `git diff --check` pass.
- Live fake-TRL OpenCode canary completed two model turns, one real sandbox tool call, and verifier execution with no idle timeout.
- Exact captured follow-up payload has four messages, string tool output, and 10 tools; normalization preserves the original OpenCode message while supplying Qwen a JSON object.
