### PR TITLE
Fit OpenCode tool output to the Qwen context window

### DIFF
--- a/docs/opencode-grpo.md
+++ b/docs/opencode-grpo.md
@@ -46,6 +46,7 @@ posttrainarena-train model-bridge \
   --tokenizer Qwen/Qwen3.5-9B \
   --tokenizer-revision <immutable-sha> \
   --max-tokens 4096 \
+  --max-context-tokens 49152 \
   --max-sidecar-entries 2048 \
   --port 8001
 ```
@@ -67,13 +68,18 @@ does not retain choice-level logprobs, the bridge also keeps a bounded
 authenticated sidecar keyed by the OpenAI completion ID. The GRPO collector
 resolves the exact sampled token IDs/logprobs from that sidecar and writes
 `grpo_tokens.json` beside each rollout attempt. The bridge caps each model turn
-at 16,384 generated tokens while the pipeline separately enforces the
+at 4,096 generated tokens while the pipeline separately enforces the
 rollout-level completion budget.
 
 On follow-up turns, OpenCode sends function arguments as JSON strings while
 Qwen3.5's chat template expects mappings. The bridge normalizes those arguments
 before forwarding the conversation to TRL; GRPO prompt reconstruction uses the
 same normalization so served and trained token IDs stay aligned.
+Before forwarding, the bridge tokenizes the complete Qwen prompt against the
+configured 49,152-token context window. If tool output would overflow the
+prompt budget, it preserves system/user messages and truncates the oldest tool
+outputs with an explicit marker. Non-tool context overflow fails before calling
+the TRL server.
 
 ## Per-update lifecycle
 

--- a/docs/training-pipeline.md
+++ b/docs/training-pipeline.md
@@ -218,6 +218,8 @@ The model bridge answers OpenCode's title-generator prompt locally with a fixed
 title, so that helper cannot consume model traffic or block task solving.
 It also converts OpenCode's stringified follow-up tool arguments back to JSON
 objects before Qwen3.5 chat-template rendering.
+The bridge fits each served prompt to the configured model context by truncating
+oldest tool outputs only; system and user instructions are never truncated.
 
 ## Execute and resume
 

--- a/pipelines/benchflow-task-posttrain/README.md
+++ b/pipelines/benchflow-task-posttrain/README.md
@@ -159,6 +159,8 @@ forwards to the TRL server at `TRL_VLLM_SERVER_BASE_URL`. The pipeline
 synchronizes the pinned base weights before baseline evaluation, SFT weights
 before SFT evaluation, the current GRPO policy before each rollout batch, and
 final weights before the held-out evaluation.
+The bridge normalizes OpenCode follow-up tool arguments and token-fits oversized
+tool results to the server context without truncating system or user messages.
 
 The final contract is:
 

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/cli.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/cli.py
@@ -178,6 +178,7 @@ def build_parser() -> argparse.ArgumentParser:
     bridge.add_argument("--tokenizer-revision")
     bridge.add_argument("--api-key-env", default="BENCHFLOW_PROVIDER_API_KEY")
     bridge.add_argument("--max-tokens", type=int, default=4096)
+    bridge.add_argument("--max-context-tokens", type=int, default=49152)
     bridge.add_argument("--max-sidecar-entries", type=int, default=2048)
     bridge.add_argument("--host", default="0.0.0.0")
     bridge.add_argument("--port", type=int, default=8001)
@@ -400,6 +401,7 @@ def main(argv: list[str] | None = None) -> int:
             tokenizer_revision=args.tokenizer_revision,
             api_key=os.environ.get(args.api_key_env),
             max_tokens_per_call=args.max_tokens,
+            max_context_tokens=args.max_context_tokens,
             max_sidecar_entries=args.max_sidecar_entries,
             host=args.host,
             port=args.port,

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/model_bridge.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/model_bridge.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import copy
 import json
+import logging
 import re
 import time
 from collections import OrderedDict
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
 from uuid import uuid4
@@ -22,6 +23,8 @@ FUNCTION_PARAMETER_PATTERN = re.compile(
     r"<parameter=([^>\n]+)>\s*(.*?)\s*</parameter>",
     re.DOTALL,
 )
+TOOL_OUTPUT_TRUNCATION_MARKER = "\n...[tool output truncated]"
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -31,6 +34,7 @@ class ModelBridgeConfig:
     tokenizer_revision: str | None = None
     api_key: str | None = None
     max_tokens_per_call: int = 4096
+    max_context_tokens: int = 49152
     timeout_seconds: float = 900.0
     max_sidecar_entries: int = 2048
 
@@ -41,6 +45,14 @@ class ModelBridgeConfig:
             or self.max_tokens_per_call < 1
         ):
             raise ValueError("max_tokens_per_call must be a positive integer")
+        if (
+            not isinstance(self.max_context_tokens, int)
+            or isinstance(self.max_context_tokens, bool)
+            or self.max_context_tokens <= self.max_tokens_per_call
+        ):
+            raise ValueError(
+                "max_context_tokens must be an integer greater than max_tokens_per_call"
+            )
         if (
             not isinstance(self.max_sidecar_entries, int)
             or isinstance(self.max_sidecar_entries, bool)
@@ -132,6 +144,115 @@ def normalize_tool_call_arguments(
                 )
             function["arguments"] = parsed
     return normalized_messages
+
+
+def _token_ids(value: Any) -> list[int]:
+    if isinstance(value, Mapping):
+        value = value.get("input_ids")
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    if isinstance(value, list) and len(value) == 1 and isinstance(value[0], list):
+        value = value[0]
+    if not isinstance(value, list) or any(
+        not isinstance(item, int) or isinstance(item, bool) for item in value
+    ):
+        raise RuntimeError("Chat template did not return token IDs")
+    return value
+
+
+def _prompt_token_count(
+    *,
+    tokenizer: Any,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None,
+) -> int:
+    kwargs: dict[str, Any] = {
+        "tokenize": True,
+        "add_generation_prompt": True,
+    }
+    if tools:
+        kwargs["tools"] = tools
+    return len(_token_ids(tokenizer.apply_chat_template(messages, **kwargs)))
+
+
+def fit_messages_to_context(
+    *,
+    tokenizer: Any,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None,
+    max_prompt_tokens: int,
+) -> tuple[list[dict[str, Any]], int, int, int]:
+    """Fit a prompt by truncating oldest tool outputs, never user instructions."""
+    if max_prompt_tokens < 1:
+        raise ValueError("max_prompt_tokens must be positive")
+    fitted = copy.deepcopy(messages)
+    original_tokens = _prompt_token_count(
+        tokenizer=tokenizer,
+        messages=fitted,
+        tools=tools,
+    )
+    if original_tokens <= max_prompt_tokens:
+        return fitted, original_tokens, original_tokens, 0
+
+    truncated_messages = 0
+    for index, message in enumerate(fitted):
+        content = message.get("content")
+        if (
+            message.get("role") != "tool"
+            or not isinstance(content, str)
+            or len(content) <= len(TOOL_OUTPUT_TRUNCATION_MARKER)
+        ):
+            continue
+        message["content"] = TOOL_OUTPUT_TRUNCATION_MARKER
+        truncated_messages += 1
+        minimal_tokens = _prompt_token_count(
+            tokenizer=tokenizer,
+            messages=fitted,
+            tools=tools,
+        )
+        if minimal_tokens > max_prompt_tokens:
+            continue
+
+        low = 0
+        high = len(content)
+        while low < high:
+            midpoint = (low + high + 1) // 2
+            fitted[index]["content"] = (
+                content[:midpoint] + TOOL_OUTPUT_TRUNCATION_MARKER
+            )
+            tokens = _prompt_token_count(
+                tokenizer=tokenizer,
+                messages=fitted,
+                tools=tools,
+            )
+            if tokens <= max_prompt_tokens:
+                low = midpoint
+            else:
+                high = midpoint - 1
+        fitted[index]["content"] = content[:low] + TOOL_OUTPUT_TRUNCATION_MARKER
+        fitted_tokens = _prompt_token_count(
+            tokenizer=tokenizer,
+            messages=fitted,
+            tools=tools,
+        )
+        if fitted_tokens > max_prompt_tokens:
+            raise RuntimeError(
+                "OpenCode prompt context fitting did not converge "
+                f"({fitted_tokens} > {max_prompt_tokens} tokens)"
+            )
+        return fitted, original_tokens, fitted_tokens, truncated_messages
+
+    fitted_tokens = _prompt_token_count(
+        tokenizer=tokenizer,
+        messages=fitted,
+        tools=tools,
+    )
+    if fitted_tokens > max_prompt_tokens:
+        raise RuntimeError(
+            "OpenCode prompt exceeds the model context after truncating all "
+            f"tool outputs ({fitted_tokens} > {max_prompt_tokens} tokens)"
+        )
+    return fitted, original_tokens, fitted_tokens, truncated_messages
 
 
 def _sampled_logprob_rows(
@@ -247,7 +368,11 @@ def translate_trl_chat_response(
     }
 
 
-def _trl_request(body: dict[str, Any], config: ModelBridgeConfig) -> dict[str, Any]:
+def _trl_request(
+    body: dict[str, Any],
+    config: ModelBridgeConfig,
+    tokenizer: Any,
+) -> dict[str, Any]:
     messages = body.get("messages")
     if not isinstance(messages, list) or not messages:
         raise ValueError("messages must be a non-empty list")
@@ -274,8 +399,26 @@ def _trl_request(body: dict[str, Any], config: ModelBridgeConfig) -> dict[str, A
         if requested_max_tokens is None
         else min(int(requested_max_tokens), config.max_tokens_per_call)
     )
+    normalized_messages = normalize_tool_call_arguments(messages)
+    tools = body.get("tools")
+    fitted_messages, original_tokens, fitted_tokens, truncated_messages = (
+        fit_messages_to_context(
+            tokenizer=tokenizer,
+            messages=normalized_messages,
+            tools=tools,
+            max_prompt_tokens=config.max_context_tokens - max_tokens,
+        )
+    )
+    if truncated_messages:
+        logger.warning(
+            "Truncated %d OpenCode tool output(s) to fit model context "
+            "(%d -> %d prompt tokens)",
+            truncated_messages,
+            original_tokens,
+            fitted_tokens,
+        )
     return {
-        "messages": [normalize_tool_call_arguments(messages)],
+        "messages": [fitted_messages],
         "n": 1,
         "repetition_penalty": float(body.get("repetition_penalty", 1.0)),
         "temperature": float(temperature),
@@ -286,7 +429,7 @@ def _trl_request(body: dict[str, Any], config: ModelBridgeConfig) -> dict[str, A
         "logprobs": 0,
         "generation_kwargs": generation_kwargs,
         "chat_template_kwargs": body.get("chat_template_kwargs") or {},
-        "tools": body.get("tools"),
+        "tools": tools,
     }
 
 
@@ -441,7 +584,7 @@ def create_model_bridge_app(
             upstream = None
             translated = _title_response(model=model)
         else:
-            upstream = await chat_call(_trl_request(body, config))
+            upstream = await chat_call(_trl_request(body, config, tokenizer))
             translated = translate_trl_chat_response(
                 payload=upstream,
                 tokenizer=tokenizer,
@@ -472,6 +615,7 @@ def serve_model_bridge(
     tokenizer_revision: str | None,
     api_key: str | None,
     max_tokens_per_call: int,
+    max_context_tokens: int,
     max_sidecar_entries: int,
     host: str,
     port: int,
@@ -485,6 +629,7 @@ def serve_model_bridge(
             tokenizer_revision=tokenizer_revision,
             api_key=api_key,
             max_tokens_per_call=max_tokens_per_call,
+            max_context_tokens=max_context_tokens,
             max_sidecar_entries=max_sidecar_entries,
         )
     )

--- a/pipelines/benchflow-task-posttrain/tests/test_cli.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_cli.py
@@ -43,6 +43,8 @@ def test_model_bridge_cli_contract() -> None:
             "a" * 40,
             "--max-tokens",
             "2048",
+            "--max-context-tokens",
+            "32768",
             "--max-sidecar-entries",
             "256",
             "--port",
@@ -54,6 +56,7 @@ def test_model_bridge_cli_contract() -> None:
     assert args.tokenizer == "Qwen/Qwen3-4B"
     assert args.api_key_env == "BENCHFLOW_PROVIDER_API_KEY"
     assert args.max_tokens == 2048
+    assert args.max_context_tokens == 32768
     assert args.max_sidecar_entries == 256
     assert args.port == 9001
 

--- a/pipelines/benchflow-task-posttrain/tests/test_model_bridge.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_model_bridge.py
@@ -8,7 +8,9 @@ from fastapi.testclient import TestClient
 
 from posttrainarena.benchflow_pipeline.model_bridge import (
     ModelBridgeConfig,
+    TOOL_OUTPUT_TRUNCATION_MARKER,
     create_model_bridge_app,
+    fit_messages_to_context,
     normalize_tool_call_arguments,
     parse_qwen_tool_calls,
     translate_trl_chat_response,
@@ -25,6 +27,14 @@ class FakeTokenizer:
     ) -> str:
         del skip_special_tokens, clean_up_tokenization_spaces
         return bytes(token_ids).decode("utf-8")
+
+    def apply_chat_template(self, messages, **kwargs):
+        tools = kwargs.get("tools")
+        encoded = json.dumps(
+            {"messages": messages, "tools": tools},
+            sort_keys=True,
+        ).encode()
+        return {"input_ids": [list(encoded)]}
 
 
 def _upstream(text: str) -> dict[str, Any]:
@@ -140,6 +150,54 @@ def test_normalize_tool_call_arguments_rejects_invalid_values(arguments: str) ->
 
     with pytest.raises(RuntimeError, match="arguments"):
         normalize_tool_call_arguments(messages)
+
+
+def test_fit_messages_to_context_truncates_oldest_tool_output() -> None:
+    messages = [
+        {"role": "user", "content": "keep this instruction"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "arguments": {"filePath": "/tmp/data.csv"},
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-1",
+            "content": "x" * 1000,
+        },
+    ]
+
+    fitted, original_tokens, fitted_tokens, truncated = fit_messages_to_context(
+        tokenizer=FakeTokenizer(),
+        messages=messages,
+        tools=None,
+        max_prompt_tokens=400,
+    )
+
+    assert original_tokens > 400
+    assert fitted_tokens <= 400
+    assert truncated == 1
+    assert fitted[0] == messages[0]
+    assert fitted[2]["content"].endswith(TOOL_OUTPUT_TRUNCATION_MARKER)
+    assert messages[2]["content"] == "x" * 1000
+
+
+def test_fit_messages_to_context_rejects_oversized_user_prompt() -> None:
+    with pytest.raises(RuntimeError, match="exceeds the model context"):
+        fit_messages_to_context(
+            tokenizer=FakeTokenizer(),
+            messages=[{"role": "user", "content": "x" * 1000}],
+            tools=None,
+            max_prompt_tokens=100,
+        )
 
 
 def test_translate_trl_chat_response_preserves_token_ids_and_logprobs() -> None:
@@ -360,7 +418,7 @@ def test_model_bridge_does_not_intercept_tool_bearing_title_prompt() -> None:
     assert captured["payload"]["tools"]
 
 
-def test_model_bridge_normalizes_followup_tool_arguments_for_trl() -> None:
+def test_model_bridge_normalizes_followup_and_fits_context_for_trl() -> None:
     captured: dict[str, Any] = {}
 
     async def fake_chat(payload: dict[str, Any]) -> dict[str, Any]:
@@ -371,6 +429,8 @@ def test_model_bridge_normalizes_followup_tool_arguments_for_trl() -> None:
         ModelBridgeConfig(
             upstream_url="http://127.0.0.1:8000",
             tokenizer_id="Qwen/Qwen3-4B",
+            max_tokens_per_call=64,
+            max_context_tokens=512,
         ),
         tokenizer=FakeTokenizer(),
         chat_call=fake_chat,
@@ -397,7 +457,7 @@ def test_model_bridge_normalizes_followup_tool_arguments_for_trl() -> None:
                 {
                     "role": "tool",
                     "tool_call_id": "call-1",
-                    "content": "a,b\n1,2",
+                    "content": "x" * 1000,
                 },
             ],
         },
@@ -408,6 +468,9 @@ def test_model_bridge_normalizes_followup_tool_arguments_for_trl() -> None:
         "arguments"
     ]
     assert arguments == {"filePath": "/tmp/data.csv"}
+    tool_content = captured["payload"]["messages"][0][2]["content"]
+    assert tool_content.endswith(TOOL_OUTPUT_TRUNCATION_MARKER)
+    assert len(tool_content) < 1000
 
 
 def test_model_bridge_caps_tokens_per_call() -> None:
@@ -526,4 +589,12 @@ def test_model_bridge_rejects_invalid_token_cap() -> None:
             upstream_url="http://127.0.0.1:8000",
             tokenizer_id="Qwen/Qwen3-4B",
             max_sidecar_entries=0,
+        )
+
+    with pytest.raises(ValueError, match="max_context_tokens"):
+        ModelBridgeConfig(
+            upstream_url="http://127.0.0.1:8000",
+            tokenizer_id="Qwen/Qwen3-4B",
+            max_tokens_per_call=64,
+            max_context_tokens=64,
         )


### PR DESCRIPTION
## What changed

- Adds an explicit `--max-context-tokens` model-bridge contract, defaulting to the documented 49,152-token TRL server window.
- Tokenizes every normalized OpenCode prompt with the pinned Qwen tokenizer before calling TRL.
- Reserves the configured per-call generation budget and truncates only oldest tool-role outputs when the prompt would overflow.
- Retains the largest fitting tool-output prefix using token-count binary search and appends an explicit truncation marker.
- Never truncates system or user messages; non-tool overflow and non-convergent fitting fail before the TRL call.
- Logs the number of affected tool outputs and before/after prompt-token counts.

## Why

After PR #24 fixed Qwen tool-argument shape, the live red-wine canary still stalled on the second turn. Reconstructing the exact follow-up showed:

- Qwen chat-template rendering succeeds after argument normalization.
- The rendered prompt is `59,146` tokens.
- The TRL vLLM server is configured for `49,152` tokens and the bridge reserves `4,096` tokens for the next completion.

The model had called OpenCode's `read` tool without a line limit, so the 1,600-line CSV result alone contributed about 51k characters. vLLM remained stuck at `Rendering conversations: 0%` instead of returning a usable overflow error. The bridge is the authoritative boundary because it has the actual normalized messages, tool schema, tokenizer, generation cap, and server context contract.

## Validation

- `217` package contract tests pass.
- `48` focused bridge/CLI/GRPO tests pass.
- Ruff check/format, Python compilation, and `git diff --check` pass.
- Exact live replay fitted the previously failing prompt from `59,146` to `45,056` tokens and returned from the real Qwen3.5-9B TRL server in 8 seconds with two tool calls.
- Full BenchFlow + OpenCode + Docker red-wine canary completed in 1.7 minutes with five tool calls, no idle timeout, healthy trajectories, verifier reward `1.0`, and pass rate `1/1`.
- Unit coverage proves tool-only truncation, original-message immutability, maximum fitting under the prompt budget, oversized user-prompt rejection, CLI propagation, and invalid context configuration rejection.
