### PR TITLE
Resume incomplete strict teacher coverage

### DIFF
--- a/docs/training-pipeline.md
+++ b/docs/training-pipeline.md
@@ -239,6 +239,10 @@ only after validating the persisted run plan, exact task IDs, teacher
 selection, SFT-data digest, checkpoint digests, evaluation identity, and
 evaluation health artifacts. Use a new run name when changing a recipe or task
 list.
+Incomplete strict teacher collection reuses finished `attempt-*` directories
+and continues with only tasks that still lack an eligible rollout. Resume may
+increase `[teacher].max_attempts`; all dataset, model, reward, and training
+semantics remain immutable.
 
 The snapshot boundary also rejects byte-equivalent task packages under
 different task IDs after normalizing the package's declared task name. This is

--- a/pipelines/benchflow-task-posttrain/README.md
+++ b/pipelines/benchflow-task-posttrain/README.md
@@ -153,6 +153,9 @@ current model, datasets, task lists, harness, and training recipe; any drift
 requires a new run name. Teacher selections, converted SFT bytes, model
 checkpoints, and evaluation health artifacts are content-validated before they
 can be reused.
+If strict teacher coverage is incomplete, resume reuses completed attempts and
+continues only missing tasks. The retry budget may be increased without
+changing the rest of the persisted run plan.
 
 The public OpenCode endpoint is `posttrainarena-train model-bridge`, which
 forwards to the TRL server at `TRL_VLLM_SERVER_BASE_URL`. The pipeline

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/pipeline.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/pipeline.py
@@ -38,6 +38,28 @@ def _json_normalized(value: Any) -> Any:
     return json.loads(json.dumps(value, default=str))
 
 
+def _resume_plan_compatible(existing: dict[str, Any], current: dict[str, Any]) -> bool:
+    if existing == current:
+        return True
+    normalized_current = _json_normalized(current)
+    existing_teacher = existing.get("teacher")
+    current_teacher = normalized_current.get("teacher")
+    if not isinstance(existing_teacher, dict) or not isinstance(current_teacher, dict):
+        return False
+    existing_attempts = existing_teacher.get("max_attempts")
+    current_attempts = current_teacher.get("max_attempts")
+    if (
+        not isinstance(existing_attempts, int)
+        or isinstance(existing_attempts, bool)
+        or not isinstance(current_attempts, int)
+        or isinstance(current_attempts, bool)
+        or current_attempts < existing_attempts
+    ):
+        return False
+    current_teacher["max_attempts"] = existing_attempts
+    return existing == normalized_current
+
+
 def _sha256(path: Path) -> str:
     return file_sha256(path)
 
@@ -285,7 +307,7 @@ class Pipeline:
                     "name or restore the original plan"
                 )
             existing = load_json(plan_path)
-            if existing != current:
+            if not _resume_plan_compatible(existing, current):
                 changed = [
                     key
                     for key in sorted(set(existing) | set(current))
@@ -628,6 +650,7 @@ class Pipeline:
             self.resume
             and manifest_path.is_file()
             and self.layout.teacher_selection.is_file()
+            and self._teacher_state_has_required_count(manifest_path)
         )
         if reuse_teacher:
             self._validate_resumed_teacher_state(manifest_path)
@@ -734,6 +757,24 @@ class Pipeline:
                 "--max-length",
                 str(self.config.sft.max_length),
             ],
+        )
+
+    def _teacher_state_has_required_count(self, manifest_path: Path) -> bool:
+        try:
+            manifest = load_json(manifest_path)
+            selection = load_json(self.layout.teacher_selection)
+        except (OSError, ValueError):
+            return False
+        required = (
+            len(self.train_task_ids)
+            if self.config.teacher.require_all_tasks
+            else self.config.teacher.min_verified
+        )
+        return (
+            isinstance(manifest.get("verified_count"), int)
+            and manifest["verified_count"] >= required
+            and isinstance(selection.get("selected_count"), int)
+            and selection["selected_count"] >= required
         )
 
     def _conversion_matches_selection(

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/teacher.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/teacher.py
@@ -265,6 +265,35 @@ def _select_from_attempts(
     return selected
 
 
+def _selection_state(
+    *,
+    config: PipelineConfig,
+    attempts: list[dict[str, Any]],
+    task_ids: list[str],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    selected = _select_from_attempts(attempts, task_ids)
+    selected_task_ids = {str(row["task_id"]) for row in selected}
+    over_budget_task_ids = {
+        str(row["task_id"])
+        for row in attempts
+        if (
+            isinstance(row.get("total_tokens"), int | float)
+            and float(row["total_tokens"]) > config.teacher.max_accepted_total_tokens
+        )
+        or int(row.get("tool_calls") or 0) > config.teacher.max_accepted_tool_calls
+    }
+    remaining = [
+        task_id
+        for task_id in task_ids
+        if task_id not in selected_task_ids and task_id not in over_budget_task_ids
+    ]
+    return selected, remaining
+
+
+def _has_completed_attempt(path: Path, health_path: Path) -> bool:
+    return path.is_dir() and health_path.is_file() and any(path.rglob("result.json"))
+
+
 def collect_verified_teacher_rollouts(
     *,
     config: PipelineConfig,
@@ -277,8 +306,33 @@ def collect_verified_teacher_rollouts(
 ) -> dict[str, Any]:
     remaining = list(task_ids)
     attempts_so_far: list[dict[str, Any]] = []
-    selected_so_far: list[dict[str, Any]] = []
-    for attempt in range(1, config.teacher.max_attempts + 1):
+    first_pending_attempt = 1
+    if not runner.dry_run:
+        for attempt in range(1, config.teacher.max_attempts + 1):
+            attempt_name = f"attempt-{attempt:02d}"
+            attempt_jobs = jobs_dir / attempt_name
+            health_path = manifest_path.with_name(f"teacher_health_{attempt_name}.json")
+            if not _has_completed_attempt(attempt_jobs, health_path):
+                first_pending_attempt = attempt
+                break
+            existing_attempts, _ = _select_verified(
+                config=config,
+                jobs_dir=attempt_jobs,
+                task_ids=task_ids,
+            )
+            attempts_so_far.extend(existing_attempts)
+            _, remaining = _selection_state(
+                config=config,
+                attempts=attempts_so_far,
+                task_ids=task_ids,
+            )
+            first_pending_attempt = attempt + 1
+            if not remaining:
+                break
+
+    for attempt in range(first_pending_attempt, config.teacher.max_attempts + 1):
+        if not remaining:
+            break
         attempt_name = f"attempt-{attempt:02d}"
         attempt_jobs = jobs_dir / attempt_name
         returncode = runner.run(
@@ -314,28 +368,14 @@ def collect_verified_teacher_rollouts(
         new_attempts, _ = _select_verified(
             config=config,
             jobs_dir=attempt_jobs,
-            task_ids=remaining,
+            task_ids=task_ids,
         )
         attempts_so_far.extend(new_attempts)
-        selected_so_far = _select_from_attempts(attempts_so_far, task_ids)
-        selected_task_ids = {str(row["task_id"]) for row in selected_so_far}
-        over_budget_task_ids = {
-            str(row["task_id"])
-            for row in attempts_so_far
-            if (
-                isinstance(row.get("total_tokens"), int | float)
-                and float(row["total_tokens"])
-                > config.teacher.max_accepted_total_tokens
-            )
-            or int(row.get("tool_calls") or 0) > config.teacher.max_accepted_tool_calls
-        }
-        remaining = [
-            task_id
-            for task_id in task_ids
-            if task_id not in selected_task_ids and task_id not in over_budget_task_ids
-        ]
-        if not remaining:
-            break
+        _, remaining = _selection_state(
+            config=config,
+            attempts=attempts_so_far,
+            task_ids=task_ids,
+        )
     if runner.dry_run:
         return {
             "teacher_model": config.teacher.model,

--- a/pipelines/benchflow-task-posttrain/tests/test_pipeline.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_pipeline.py
@@ -450,7 +450,7 @@ def test_resumed_grpo_restarts_stage_instead_of_reusing_rollouts(
     assert pipeline.runner.commands[-1]["resume_policy"] == "restart-stage"
 
 
-def test_resume_rejects_insufficient_teacher_manifest(tmp_path: Path) -> None:
+def test_resume_recollects_insufficient_teacher_manifest(tmp_path: Path) -> None:
     config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
     config = replace(config, output_root=tmp_path)
     pipeline = Pipeline(
@@ -479,8 +479,12 @@ def test_resume_rejects_insufficient_teacher_manifest(tmp_path: Path) -> None:
         json.dumps({"selected_count": len(pipeline.train_task_ids) - 1})
     )
 
-    with pytest.raises(RuntimeError, match="verified_count"):
-        pipeline._collect_and_convert_teacher_data()
+    pipeline._collect_and_convert_teacher_data()
+
+    assert any(
+        command["name"] == "collect_verified_teacher_rollouts"
+        for command in pipeline.runner.commands
+    )
 
 
 def test_resume_rejects_fabricated_teacher_selection_count(tmp_path: Path) -> None:
@@ -641,7 +645,7 @@ def test_resume_checkpoint_digests_detect_tampering(tmp_path: Path) -> None:
     )
 
 
-def test_resume_rejects_changed_run_plan_before_overwriting_it(
+def test_resume_allows_increased_teacher_retry_budget(
     tmp_path: Path,
 ) -> None:
     config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
@@ -657,6 +661,33 @@ def test_resume_rejects_changed_run_plan_before_overwriting_it(
             ),
         ),
         run_name="resume-plan",
+        dry_run=True,
+        resume=True,
+    )
+
+    changed._prepare_run_plan()
+
+    updated = json.loads((changed.layout.reports / "plan.json").read_text())
+    assert updated["teacher"]["max_attempts"] == (
+        original_plan["teacher"]["max_attempts"] + 1
+    )
+
+
+def test_resume_rejects_other_teacher_plan_changes(tmp_path: Path) -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    config = replace(config, output_root=tmp_path)
+    original = Pipeline(config, run_name="resume-plan-drift", dry_run=True)
+    original._prepare_run_plan()
+    original_plan = json.loads((original.layout.reports / "plan.json").read_text())
+    changed = Pipeline(
+        replace(
+            config,
+            teacher=replace(
+                config.teacher,
+                min_reward=config.teacher.min_reward - 0.1,
+            ),
+        ),
+        run_name="resume-plan-drift",
         dry_run=True,
         resume=True,
     )

--- a/pipelines/benchflow-task-posttrain/tests/test_teacher.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_teacher.py
@@ -487,6 +487,105 @@ def test_collect_teacher_retries_only_tasks_without_verified_rollout(
     assert selection["selected_count"] == 2
 
 
+def test_collect_teacher_reuses_existing_attempts_before_continuing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    config = replace(
+        config,
+        teacher=replace(config.teacher, max_attempts=2, min_verified=2),
+    )
+    existing_rollout = tmp_path / "jobs" / "attempt-01" / "task-a__existing"
+    existing_rollout.mkdir(parents=True)
+    (existing_rollout / "result.json").write_text("{}")
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    (reports / "teacher_health_attempt-01.json").write_text("{}")
+    runner = FakeRunner(ROOT, dry_run=False)
+    task_a = {
+        "task_id": "task-a",
+        "rollout_dir": str(existing_rollout),
+        "reward": 1.0,
+        "eligible": True,
+    }
+    task_b = {
+        "task_id": "task-b",
+        "rollout_dir": str(tmp_path / "task-b"),
+        "reward": 1.0,
+        "eligible": True,
+    }
+    responses = iter(
+        [
+            ([task_a], [task_a]),
+            ([task_b], [task_b]),
+        ]
+    )
+    monkeypatch.setattr(
+        "posttrainarena.benchflow_pipeline.teacher._select_verified",
+        lambda **_kwargs: next(responses),
+    )
+
+    manifest = collect_verified_teacher_rollouts(
+        config=config,
+        runner=runner,
+        tasks_dir=tmp_path / "tasks",
+        task_ids=["task-a", "task-b"],
+        jobs_dir=tmp_path / "jobs",
+        manifest_path=reports / "teacher.json",
+        selection_path=reports / "selection.json",
+    )
+
+    assert manifest["verified_count"] == 2
+    assert [record["name"] for record in runner.commands] == [
+        "collect_verified_teacher_rollouts_attempt-02"
+    ]
+    command = runner.commands[0]["command"]
+    assert command.count("--include") == 1
+    assert "task-b" in command
+    assert "task-a" not in command
+
+
+def test_collect_teacher_restarts_incomplete_existing_attempt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    config = replace(
+        config,
+        teacher=replace(config.teacher, max_attempts=1, min_verified=1),
+    )
+    stale_rollout = tmp_path / "jobs" / "attempt-01" / "task-a__stale"
+    stale_rollout.mkdir(parents=True)
+    (stale_rollout / "result.json").write_text("{}")
+    runner = FakeRunner(ROOT, dry_run=False)
+    selected = {
+        "task_id": "task-a",
+        "rollout_dir": str(tmp_path / "task-a"),
+        "reward": 1.0,
+        "eligible": True,
+    }
+    monkeypatch.setattr(
+        "posttrainarena.benchflow_pipeline.teacher._select_verified",
+        lambda **_kwargs: ([selected], [selected]),
+    )
+
+    manifest = collect_verified_teacher_rollouts(
+        config=config,
+        runner=runner,
+        tasks_dir=tmp_path / "tasks",
+        task_ids=["task-a"],
+        jobs_dir=tmp_path / "jobs",
+        manifest_path=tmp_path / "reports" / "teacher.json",
+        selection_path=tmp_path / "reports" / "selection.json",
+    )
+
+    assert manifest["verified_count"] == 1
+    assert [record["name"] for record in runner.commands] == [
+        "collect_verified_teacher_rollouts"
+    ]
+
+
 def test_collect_teacher_retries_after_rollout_exit_one(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## What changed

- Reuses completed `jobs/teacher/attempt-*` directories when strict teacher collection resumes.
- Recomputes selection across preserved attempts and runs only task IDs that still lack an eligible rollout.
- Restarts an interrupted attempt when its terminal health marker is missing.
- Treats an insufficient teacher manifest as incomplete work to continue, not as a completed state to reject.
- Allows one safe persisted-plan change on resume: increasing `teacher.max_attempts`. Decreasing it or changing dataset/model/reward/training semantics still fails closed.

## Why

The merged-main red-wine full run completed a healthy deterministic `8/14` baseline and three strict 397B teacher attempts, then stopped at `11/16` eligible trajectories as configured. All existing baseline and teacher artifacts are valid and expensive, but the current resume path cannot continue them:

- `collect_verified_teacher_rollouts` always starts again at attempt 1.
- `_collect_and_convert_teacher_data` treats an insufficient manifest as a reusable completed stage, then rejects it.
- The saved-plan guard rejects increasing only the retry budget.

That makes strict all-task coverage non-resumable even though the next correct action is simply attempt 4 on the five missing task IDs.

## Validation

- `222` package contract tests pass.
- `36` focused teacher/pipeline tests pass.
- Ruff check/format, Python compilation, and `git diff --check` pass.
- New coverage proves completed-attempt reuse, missing-task-only continuation, interrupted-attempt restart, insufficient-manifest recollection, safe retry-budget increase, and rejection of all other teacher recipe drift.
- Live preserved state contains three complete attempts, 11 selected training-ready reward-1 trajectories, and exactly five remaining task IDs.
