### PR TITLE
Increase data-agent GRPO completion budget

### DIFF
--- a/docs/training-pipeline.md
+++ b/docs/training-pipeline.md
@@ -241,8 +241,8 @@ evaluation health artifacts. Use a new run name when changing a recipe or task
 list.
 Incomplete strict teacher collection reuses finished `attempt-*` directories
 and continues with only tasks that still lack an eligible rollout. Resume may
-increase `[teacher].max_attempts`; all dataset, model, reward, and training
-semantics remain immutable.
+increase `[teacher].max_attempts` or `[runtime].max_completion_length`; all
+dataset, model, reward, and optimizer semantics remain immutable.
 
 The snapshot boundary also rejects byte-equivalent task packages under
 different task IDs after normalizing the package's declared task name. This is

--- a/pipelines/benchflow-task-posttrain/README.md
+++ b/pipelines/benchflow-task-posttrain/README.md
@@ -156,6 +156,8 @@ can be reused.
 If strict teacher coverage is incomplete, resume reuses completed attempts and
 continues only missing tasks. The retry budget may be increased without
 changing the rest of the persisted run plan.
+An interrupted GRPO stage also permits increasing only the aggregate completion
+budget, then restarts cleanly from the saved SFT checkpoint.
 
 The public OpenCode endpoint is `posttrainarena-train model-bridge`, which
 forwards to the TRL server at `TRL_VLLM_SERVER_BASE_URL`. The pipeline

--- a/pipelines/benchflow-task-posttrain/configs/qwen3.5-9b-data-agent-full.toml
+++ b/pipelines/benchflow-task-posttrain/configs/qwen3.5-9b-data-agent-full.toml
@@ -17,7 +17,7 @@ task_list = "../task-lists/data-agent-eval-all.txt"
 [runtime]
 sandbox = "docker"
 sandbox_user = "agent"
-max_completion_length = 16384
+max_completion_length = 40960
 num_generations = 2
 
 [harness]

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/pipeline.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/pipeline.py
@@ -42,21 +42,27 @@ def _resume_plan_compatible(existing: dict[str, Any], current: dict[str, Any]) -
     if existing == current:
         return True
     normalized_current = _json_normalized(current)
-    existing_teacher = existing.get("teacher")
-    current_teacher = normalized_current.get("teacher")
-    if not isinstance(existing_teacher, dict) or not isinstance(current_teacher, dict):
-        return False
-    existing_attempts = existing_teacher.get("max_attempts")
-    current_attempts = current_teacher.get("max_attempts")
-    if (
-        not isinstance(existing_attempts, int)
-        or isinstance(existing_attempts, bool)
-        or not isinstance(current_attempts, int)
-        or isinstance(current_attempts, bool)
-        or current_attempts < existing_attempts
+    for section, field in (
+        ("teacher", "max_attempts"),
+        ("runtime", "max_completion_length"),
     ):
-        return False
-    current_teacher["max_attempts"] = existing_attempts
+        existing_section = existing.get(section)
+        current_section = normalized_current.get(section)
+        if not isinstance(existing_section, dict) or not isinstance(
+            current_section, dict
+        ):
+            return False
+        existing_value = existing_section.get(field)
+        current_value = current_section.get(field)
+        if (
+            not isinstance(existing_value, int)
+            or isinstance(existing_value, bool)
+            or not isinstance(current_value, int)
+            or isinstance(current_value, bool)
+            or current_value < existing_value
+        ):
+            return False
+        current_section[field] = existing_value
     return existing == normalized_current
 
 

--- a/pipelines/benchflow-task-posttrain/tests/test_config.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_config.py
@@ -65,6 +65,7 @@ def test_qwen35_full_recipe_uses_all_tasks_and_one_epoch_lora() -> None:
     )
     assert config.teacher.require_all_tasks is True
     assert config.teacher.min_verified == 2238
+    assert config.runtime.max_completion_length == 40960
     assert config.sft.num_train_epochs == 1.0
     assert config.sft.max_steps is None
     assert config.sft.lora_r == 16

--- a/pipelines/benchflow-task-posttrain/tests/test_pipeline.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_pipeline.py
@@ -673,6 +673,33 @@ def test_resume_allows_increased_teacher_retry_budget(
     )
 
 
+def test_resume_allows_increased_grpo_completion_budget(tmp_path: Path) -> None:
+    config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
+    config = replace(config, output_root=tmp_path)
+    original = Pipeline(config, run_name="resume-grpo-budget", dry_run=True)
+    original._prepare_run_plan()
+    original_plan = json.loads((original.layout.reports / "plan.json").read_text())
+    changed = Pipeline(
+        replace(
+            config,
+            runtime=replace(
+                config.runtime,
+                max_completion_length=config.runtime.max_completion_length * 2,
+            ),
+        ),
+        run_name="resume-grpo-budget",
+        dry_run=True,
+        resume=True,
+    )
+
+    changed._prepare_run_plan()
+
+    updated = json.loads((changed.layout.reports / "plan.json").read_text())
+    assert updated["runtime"]["max_completion_length"] == (
+        original_plan["runtime"]["max_completion_length"] * 2
+    )
+
+
 def test_resume_rejects_other_teacher_plan_changes(tmp_path: Path) -> None:
     config = load_config(ROOT / "configs/qwen3-4b-data-agent-smoke.toml")
     config = replace(config, output_root=tmp_path)


### PR DESCRIPTION
## What changed

- Raises the full Qwen3.5 data-agent recipe's aggregate GRPO completion budget from `16,384` to `40,960` tokens.
- Allows only a non-decreasing `runtime.max_completion_length` change when resuming a persisted run.
- Keeps dataset, model, reward, optimizer, LoRA, and epoch settings immutable.
- Documents that an interrupted GRPO stage restarts cleanly from the saved SFT checkpoint after the budget increase.

## Why

The live strict red-wine run completed 16/16 teacher coverage, one-epoch LoRA SFT, and a 15/16 GRPO gate. GRPO then failed on a valid reward-1 OpenCode rollout because its exact causal sequence contained `37,367` tokens including masked tool feedback. Both retries for a later rollout were about `37.1k`, so the existing 16k cap is below normal data-agent trajectories.

The bridge already fits each served model prompt to 49,152 tokens and the SFT recipe supports 40,960-token rows. Matching the aggregate rollout budget to 40,960 accepts these healthy traces while remaining below the server context contract.

The failed GRPO stage had `loss=0`, `grad_norm=0`, and zero reward variance through its first eight steps, so restarting from the preserved SFT checkpoint loses no learned GRPO update.

## Validation

- `223` package contract tests pass.
- `87` focused config/pipeline tests pass.
- Ruff check/format, Python compilation, and `git diff --check` pass.
- The red-wine v3 recipe validates and plans with `max_completion_length=40960`.
