### PR TITLE
Fit OpenCode generation budget to context

### DIFF
--- a/docs/opencode-grpo.md
+++ b/docs/opencode-grpo.md
@@ -79,8 +79,9 @@ same normalization so served and trained token IDs stay aligned.
 Before forwarding, the bridge tokenizes the complete Qwen prompt against the
 configured 49,152-token context window. If tool output would overflow the
 prompt budget, it preserves system/user messages and truncates the oldest tool
-outputs with an explicit marker. Non-tool context overflow fails before calling
-the TRL server.
+outputs with an explicit marker. If the irreducible prompt exceeds the reserved
+prompt budget, the bridge reduces that turn's generation allowance;
+it fails only when the prompt leaves no token available for generation.
 Sampled-logprob GRPO requests use a stricter 16,384-token context cap so TRL can
 recompute policy logprobs on one H100 without materializing 49k-token logits.
 Ordinary baseline, SFT, and final evaluation keep the full context window.

--- a/docs/training-pipeline.md
+++ b/docs/training-pipeline.md
@@ -220,6 +220,8 @@ It also converts OpenCode's stringified follow-up tool arguments back to JSON
 objects before Qwen3.5 chat-template rendering.
 The bridge fits each served prompt to the configured model context by truncating
 oldest tool outputs only; system and user instructions are never truncated.
+It dynamically reduces the per-turn generation allowance when irreducible
+prompt overhead would otherwise exceed the reserved prompt budget.
 GRPO sampled-logprob requests use a smaller context cap than evaluation requests
 to keep trainer-side policy-logprob recomputation within GPU memory.
 The CLI enables PyTorch expandable CUDA segments unless the operator already

--- a/pipelines/benchflow-task-posttrain/README.md
+++ b/pipelines/benchflow-task-posttrain/README.md
@@ -166,6 +166,8 @@ before SFT evaluation, the current GRPO policy before each rollout batch, and
 final weights before the held-out evaluation.
 The bridge normalizes OpenCode follow-up tool arguments and token-fits oversized
 tool results to the server context without truncating system or user messages.
+If irreducible prompt overhead consumes part of the completion reserve, the
+bridge reduces only that turn's generation allowance.
 Its sampled-logprob path uses a stricter context cap for trainer memory while
 ordinary evaluation retains the full model context.
 CLI runs also enable expandable CUDA segments by default to reduce GRPO memory

--- a/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/model_bridge.py
+++ b/pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/model_bridge.py
@@ -24,6 +24,7 @@ FUNCTION_PARAMETER_PATTERN = re.compile(
     re.DOTALL,
 )
 TOOL_OUTPUT_TRUNCATION_MARKER = "\n...[tool output truncated]"
+RESERVED_GENERATION_KWARGS = frozenset({"logprobs", "max_tokens", "n"})
 logger = logging.getLogger(__name__)
 
 
@@ -185,6 +186,34 @@ def _prompt_token_count(
     return len(_token_ids(tokenizer.apply_chat_template(messages, **kwargs)))
 
 
+def _truncatable_tool_output(message: dict[str, Any]) -> str | None:
+    content = message.get("content")
+    if (
+        message.get("role") == "tool"
+        and isinstance(content, str)
+        and len(content) > len(TOOL_OUTPUT_TRUNCATION_MARKER)
+    ):
+        return content
+    return None
+
+
+def _minimal_prompt_token_count(
+    *,
+    tokenizer: Any,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None,
+) -> int:
+    minimal_messages = copy.deepcopy(messages)
+    for message in minimal_messages:
+        if _truncatable_tool_output(message) is not None:
+            message["content"] = TOOL_OUTPUT_TRUNCATION_MARKER
+    return _prompt_token_count(
+        tokenizer=tokenizer,
+        messages=minimal_messages,
+        tools=tools,
+    )
+
+
 def fit_messages_to_context(
     *,
     tokenizer: Any,
@@ -206,12 +235,8 @@ def fit_messages_to_context(
 
     truncated_messages = 0
     for index, message in enumerate(fitted):
-        content = message.get("content")
-        if (
-            message.get("role") != "tool"
-            or not isinstance(content, str)
-            or len(content) <= len(TOOL_OUTPUT_TRUNCATION_MARKER)
-        ):
+        content = _truncatable_tool_output(message)
+        if content is None:
             continue
         message["content"] = TOOL_OUTPUT_TRUNCATION_MARKER
         truncated_messages += 1
@@ -394,7 +419,13 @@ def _trl_request(
             generation_kwargs[key] = body[key]
     extra_body = body.get("extra_body")
     if isinstance(extra_body, dict):
-        generation_kwargs.update(extra_body)
+        generation_kwargs.update(
+            {
+                key: value
+                for key, value in extra_body.items()
+                if key not in RESERVED_GENERATION_KWARGS
+            }
+        )
     capture_logprobs = body.get("logprobs") is True
     if not capture_logprobs and body.get("tools") and body.get("seed") is None:
         generation_kwargs["seed"] = 0
@@ -414,6 +445,27 @@ def _trl_request(
     context_tokens = config.max_context_tokens
     if capture_logprobs:
         context_tokens = min(context_tokens, config.max_logprob_context_tokens)
+    minimal_prompt_tokens = _minimal_prompt_token_count(
+        tokenizer=tokenizer,
+        messages=normalized_messages,
+        tools=tools,
+    )
+    if minimal_prompt_tokens >= context_tokens:
+        raise RuntimeError(
+            "OpenCode prompt leaves no generation capacity after truncating all "
+            f"tool outputs ({minimal_prompt_tokens} >= {context_tokens} tokens)"
+        )
+    requested_generation_tokens = max_tokens
+    max_tokens = min(max_tokens, context_tokens - minimal_prompt_tokens)
+    if max_tokens < requested_generation_tokens:
+        logger.warning(
+            "Reduced OpenCode generation budget to fit irreducible prompt "
+            "(%d -> %d max tokens; %d prompt tokens; %d context tokens)",
+            requested_generation_tokens,
+            max_tokens,
+            minimal_prompt_tokens,
+            context_tokens,
+        )
     fitted_messages, original_tokens, fitted_tokens, truncated_messages = (
         fit_messages_to_context(
             tokenizer=tokenizer,

--- a/pipelines/benchflow-task-posttrain/tests/test_model_bridge.py
+++ b/pipelines/benchflow-task-posttrain/tests/test_model_bridge.py
@@ -37,6 +37,15 @@ class FakeTokenizer:
         return {"input_ids": [list(encoded)]}
 
 
+class FixedPromptTokenizer(FakeTokenizer):
+    def __init__(self, prompt_tokens: int) -> None:
+        self.prompt_tokens = prompt_tokens
+
+    def apply_chat_template(self, messages, **kwargs):
+        del messages, kwargs
+        return {"input_ids": [[0] * self.prompt_tokens]}
+
+
 def _upstream(text: str) -> dict[str, Any]:
     token_ids = list(text.encode("utf-8"))
     return {
@@ -533,6 +542,104 @@ def test_model_bridge_uses_stricter_context_for_logprob_requests() -> None:
     )
     assert prompt_tokens <= 384
     assert payload["messages"][0][2]["content"].endswith(TOOL_OUTPUT_TRUNCATION_MARKER)
+
+
+@pytest.mark.parametrize(
+    ("prompt_tokens", "expected_max_tokens"),
+    [
+        (12288, 4096),
+        (12289, 4095),
+        (12306, 4078),
+        (16383, 1),
+    ],
+)
+def test_model_bridge_fits_irreducible_prompt_generation_budget(
+    prompt_tokens: int,
+    expected_max_tokens: int,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_chat(payload: dict[str, Any]) -> dict[str, Any]:
+        captured["payload"] = payload
+        return _upstream("OK")
+
+    app = create_model_bridge_app(
+        ModelBridgeConfig(
+            upstream_url="http://127.0.0.1:8000",
+            tokenizer_id="Qwen/Qwen3.5-9B",
+            max_tokens_per_call=4096,
+            max_context_tokens=49152,
+            max_logprob_context_tokens=16384,
+        ),
+        tokenizer=FixedPromptTokenizer(prompt_tokens=prompt_tokens),
+        chat_call=fake_chat,
+    )
+    response = TestClient(app).post(
+        "/v1/chat/completions",
+        json={
+            "messages": [{"role": "user", "content": "irreducible OpenCode prompt"}],
+            "logprobs": True,
+            "extra_body": {"max_tokens": 4096, "top_k": 42},
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured["payload"]["max_tokens"] == expected_max_tokens
+    assert captured["payload"]["generation_kwargs"] == {"top_k": 42}
+
+
+def test_model_bridge_keeps_full_context_for_non_logprob_requests() -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_chat(payload: dict[str, Any]) -> dict[str, Any]:
+        captured["payload"] = payload
+        return _upstream("OK")
+
+    app = create_model_bridge_app(
+        ModelBridgeConfig(
+            upstream_url="http://127.0.0.1:8000",
+            tokenizer_id="Qwen/Qwen3.5-9B",
+            max_tokens_per_call=4096,
+            max_context_tokens=49152,
+            max_logprob_context_tokens=16384,
+        ),
+        tokenizer=FixedPromptTokenizer(prompt_tokens=45000),
+        chat_call=fake_chat,
+    )
+    response = TestClient(app).post(
+        "/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": "evaluation prompt"}]},
+    )
+
+    assert response.status_code == 200
+    assert captured["payload"]["max_tokens"] == 4096
+
+
+def test_model_bridge_rejects_prompt_with_no_generation_capacity() -> None:
+    async def fake_chat(payload: dict[str, Any]) -> dict[str, Any]:
+        del payload
+        return _upstream("OK")
+
+    app = create_model_bridge_app(
+        ModelBridgeConfig(
+            upstream_url="http://127.0.0.1:8000",
+            tokenizer_id="Qwen/Qwen3.5-9B",
+            max_tokens_per_call=4096,
+            max_context_tokens=49152,
+            max_logprob_context_tokens=16384,
+        ),
+        tokenizer=FixedPromptTokenizer(prompt_tokens=16384),
+        chat_call=fake_chat,
+    )
+
+    with pytest.raises(RuntimeError, match="no generation capacity"):
+        TestClient(app).post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "irreducible OpenCode prompt"}],
+                "logprobs": True,
+            },
+        )
 
 
 def test_model_bridge_caps_tokens_per_call() -> None:


### PR DESCRIPTION
## Summary

- measure the irreducible OpenCode prompt before reserving completion tokens
- reduce only the per-turn generation allowance when the prompt needs part of that reserve
- reject prompts only when no generation token can fit
- prevent `extra_body` from overriding enforced `max_tokens`, `n`, or `logprobs`
- cover the real 12,306-token GRPO regression plus exact boundary and full-evaluation-context cases

## Verification

- `pytest pipelines/benchflow-task-posttrain/tests -q` (228 passed)
- `ruff check pipelines/benchflow-task-posttrain/src pipelines/benchflow-task-posttrain/tests`
- `python -m compileall -q pipelines/benchflow-task-posttrain/src`
- `git diff --check`
