### PR TITLE
docs: align pipeline and dataset guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to PostTrain Arena
 
+<!-- markdownlint-disable MD013 MD060 -->
+
 PostTrain Arena is a proposed NeurIPS 2026 competition: teams
 contribute containerized RL environments, the organizers run a managed
 SFT→GRPO post-training pipeline on **each team's corpus**, and entries
@@ -82,12 +84,13 @@ baseline trained with the identical recipe, with paired bootstrap
 confidence intervals. Track 1 packages are evaluated by pass@1 of a
 frozen reference agent — no training, no internet.
 
-Qwen3.5-9B is the checked-in organizer recipe. The current
-eight-train/three-eval Data Agent canary completed the orchestration path with
-held-out pass rate unchanged at `1/3`, but a post-run audit invalidated its old
-GRPO prompt reconstruction. A corrected matched-domain rerun and full-scale
-validation remain the current targets while the final competition compute
-budget is frozen. See
+Qwen3.5-9B is the checked-in organizer recipe. The corrected 16-train/14-eval
+Data Agent canary completed strict teacher coverage, one-epoch LoRA SFT,
+128 OpenCode GRPO rollouts, and healthy held-out evaluation. Pass rate improved
+from `8/14` to `11/14` with zero regressions. This validates the executable
+recipe and records exploratory same-domain uplift; it does not establish
+generalization. The participant-scale run and sealed private suite remain
+organizer-only competition stages. See
 [`docs/training-pipeline.md`](./docs/training-pipeline.md) for exact executable
 behavior and evidence boundaries.
 
@@ -116,9 +119,11 @@ part of the contract.
 ### Step-by-step
 
 1. **Copy the template** into your team entry:
+
    ```bash
    cp -R starting-kit/template submissions/your-team/envs/your-env-name
    ```
+
    Pick a name following `<env-or-domain>-<short-description>` — for
    example `gmail-workflow-delegation`. Category, modality, and any
    safety qualifier belong in the frontmatter, not the directory name.
@@ -128,6 +133,7 @@ part of the contract.
    layouts.
 3. **Validate locally** — everything runs with just python3 and
    docker, no benchflow install:
+
    ```bash
    # Structural — fast, no Docker required
    python3 scripts/check_task.py submissions/your-team/envs
@@ -139,6 +145,7 @@ part of the contract.
    # Empty trial — prove the verifier rejects a do-nothing run
    scripts/run_local.sh submissions/your-team/envs/your-env-name --skip-oracle
    ```
+
    Get all four green before opening a PR: the oracle replay must
    score 1.0 and the empty trial must not.
 4. **Open a pull request** adding or updating your team entry. In the

--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@ The open arena for post-training: contribute agentic RL environments, then measu
 **[Website](https://posttrain.com)** · **[Authoring spec](https://posttrain.com/docs/spec)** · **[Training pipeline](./docs/training-pipeline.md)** · **[Architecture status](./docs/architecture-status.md)** · **[Contributing](./CONTRIBUTING.md)** · **[Discord](https://discord.gg/mZ9Rc8q8W3)**
 
 > [!IMPORTANT]
-> PostTrain Arena is a proposed NeurIPS 2026 competition. The checked-in organizer recipe now targets `Qwen/Qwen3.5-9B`, uses `Qwen/Qwen3.5-397B-A17B` teacher rollouts, and runs one-epoch LoRA SFT followed by LoRA GRPO. Both the older Qwen3-4B path and a Qwen3.5 Data Agent canary have end-to-end execution evidence; neither has yet demonstrated held-out model-quality lift.
+> PostTrain Arena is a proposed NeurIPS 2026 competition. The checked-in
+> organizer recipe targets `Qwen/Qwen3.5-9B`, uses
+> `Qwen/Qwen3.5-397B-A17B` teacher rollouts, and runs one-epoch LoRA SFT
+> followed by LoRA GRPO through OpenCode. An exploratory same-domain public
+> canary observed a pass-rate increase from `8/14` to `11/14`;
+> competition-scale generalization and sealed-suite claims still require the
+> private organizer run.
 
 ## How it works
 
@@ -38,9 +44,13 @@ The headline track rewards environments that teach capabilities which transfer b
 
 ## Public implementation status
 
-The checked-in implementation now includes the full public-data organizer
-recipe plus a live Qwen3.5 eight-train/three-eval canary. Competition-scale
-execution, measured lift, and the sealed evaluation remain pending.
+The checked-in implementation now includes the full public-data reference
+recipe plus an exploratory Qwen3.5 16-train/14-eval canary. The same pipeline
+is used for competition entries by replacing the training dataset/task list
+with the participant corpus and the public eval dataset/task list with the
+organizer's sealed internal set. Competition-scale execution and sealed
+evaluation remain pending; the public canary records a same-domain pass-rate
+increase, not a generalization result.
 
 | Surface | Current public status |
 | --- | --- |
@@ -49,24 +59,23 @@ execution, measured lift, and the sealed evaluation remain pending.
 | OpenCode agent harness | **Implemented end to end** — teacher collection, baseline/gate/final eval, benchmark matrices, and TRL custom GRPO rollouts use OpenCode; TRL synchronizes the pinned base and each trained policy to the shared vLLM endpoint |
 | Public data | **Available** — [2,238 training tasks](https://huggingface.co/datasets/benchflow/data_agent_rl_environment_train) and [366 held-out evaluation tasks](https://huggingface.co/datasets/benchflow/data_agent_rl_environment_eval) in native `task.md` format |
 | OpenEnv protocol path | **Implemented** — served adapter, typed client, lifecycle tests, Docker parity validation, and a native-dataset end-to-end smoke |
-| HF Jobs execution | **Implemented** — portable UV job bundles, pinned code refs, named-secret boundaries, status inspection, and Hub publishing; live scheduler allocation currently awaits HF credits |
+| HF Jobs handoff | **Implemented; current topology not scheduler-validated** — portable UV job bundles, pinned code refs, named-secret boundaries, status inspection, and Hub publishing are implemented; July 11 scheduler attempts were credit-blocked, and the Qwen3.5/OpenCode topology still needs a paid HF Jobs run |
 | Continuous leaderboard | **Implemented** — atomic Hub dataset records and a deployable Gradio Space |
 | Multi-benchmark evaluation | **Implemented** — one base/final checkpoint pair can be scored across pinned Data Agent and SkillsBench suites |
-| Qwen3.5-9B organizer recipe | **Implemented; corrected live rerun in progress** — full 2,238-train/366-eval config is checked in; the 8x3 run proved orchestration but exposed a GRPO prompt-ID mismatch that this branch fixes |
-| Demonstrated model-quality lift | **Not yet** — completed smokes validated system mechanics, not learning gains |
+| Qwen3.5-9B organizer recipe | **Implemented and live canary validated** — full 2,238-train/366-eval public config is checked in; the corrected exact-ID 16x14 run completed SFT, 128 GRPO rollouts, final synchronization, and evaluation |
+| Observed canary uplift | **Exploratory same-domain evidence** — `8/14 → 11/14` (`+21.4` percentage points), with zero task regressions; the slice was diagnostic rather than pre-registered and the paired 95% interval includes zero |
 
 > [!NOTE]
-> On July 10, 2026, a real one-train/one-held-out run completed snapshotting, baseline evaluation, verifier-approved teacher collection, LoRA SFT, a forced GRPO step, final evaluation, and artifact publication through the earlier OpenEnv/TRL evaluation path. Scores remained `0.0 → 0.0`, so this is evidence of end-to-end operability—not quality improvement and not validation of the newer OpenCode evaluation path. See the [native-dataset OpenEnv smoke report](https://github.com/benchflow-ai/posttrainarena/blob/main/docs/native-dataset-openenv-smoke.md).
+> On July 10, 2026, a real one-train/one-held-out run completed snapshotting, baseline evaluation, verifier-approved teacher collection, LoRA SFT, a forced GRPO step, final evaluation, and artifact publication through the earlier OpenEnv/TRL evaluation path. Scores remained `0.0 → 0.0`, so this is evidence of end-to-end operability—not quality improvement and not validation of the newer OpenCode evaluation path. See the [native-dataset OpenEnv smoke report](./docs/native-dataset-openenv-smoke.md).
 >
-> On July 14, 2026, an eight-training-task/three-held-out-task Qwen3.5-9B
-> canary completed the current Docker + OpenCode path, including four verified
-> teacher trajectories, one-epoch LoRA SFT, 16 OpenCode GRPO rollouts,
-> checkpoint synchronization, and final held-out evaluation. Baseline, SFT,
-> and final held-out pass rate each measured `1/3`, so delta remained `0.0`.
-> A post-run audit found that the historical GRPO parser retokenized prompts
-> differently from the serving endpoint, so this run is not valid GRPO
-> learning evidence. The corrected path uses exact served IDs and policy
-> attestation.
+> On July 15, 2026, the corrected Qwen3.5-9B Docker + OpenCode run used 16
+> training task IDs and 14 disjoint evaluation task IDs from the same red-wine
+> source dataset. It completed strict `16/16` teacher coverage, 63 SFT rows,
+> one LoRA SFT epoch, 128 OpenCode GRPO rollouts, finite nonzero LoRA updates,
+> and a healthy final evaluation. Pass rate increased `8/14 → 11/14`, with zero
+> regressions. This diagnostic slice validates the update path but is not
+> evidence of broad generalization. The earlier July 14 soccer canary is
+> retained in the evidence report as historical orchestration-only data.
 > See the
 > [Qwen3.5 Data Agent canary](./docs/qwen35-data-agent-e2e-canary.md).
 
@@ -79,7 +88,7 @@ For compatibility details and evidence boundaries, use [Architecture and impleme
 | [`starting-kit/`](./starting-kit) | Task template and organizer-authored examples |
 | [`submissions/`](./submissions) | Team entries and `submission.yaml` contract |
 | [`scripts/`](./scripts) | Self-contained structural checks and local Docker harness |
-| [`pipelines/benchflow-task-posttrain/`](./pipelines/benchflow-task-posttrain) | Public BenchFlow + OpenEnv + TRL training implementation |
+| [`pipelines/benchflow-task-posttrain/`](./pipelines/benchflow-task-posttrain) | Public BenchFlow + OpenCode + TRL training implementation and standalone OpenEnv adapter |
 | [`docs/`](./docs) | Architecture, operator guide, and validation evidence |
 
 The examples under `starting-kit/` are reference material, not competition entries.
@@ -110,17 +119,18 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the submission workflow, validation
 
 ## Documentation
 
+- [Documentation map](./docs/README.md)
 - [Task authoring specification](https://posttrain.com/docs/spec)
 - [Architecture and implementation status](./docs/architecture-status.md)
 - [Training pipeline operator guide](./docs/training-pipeline.md)
 - [OpenCode GRPO rollout contract](./docs/opencode-grpo.md)
 - [OpenCode SFT-to-GRPO smoke](./docs/opencode-grpo-smoke.md)
 - [Qwen3.5 OpenCode teacher canary](./docs/qwen35-opencode-teacher-canary.md)
-- [Qwen3.5 Data Agent SFT-to-GRPO canary](./docs/qwen35-data-agent-e2e-canary.md)
+- [Qwen3.5 Data Agent SFT-to-GRPO validation](./docs/qwen35-data-agent-e2e-canary.md)
 - [OpenCode evaluation canary](./docs/opencode-evaluation-canary.md)
 - [Hugging Face Jobs and leaderboard handoff](./docs/hf-jobs.md)
 - [HF handoff validation report](./docs/hf-jobs-validation.md)
-- [Native-dataset OpenEnv smoke report](https://github.com/benchflow-ai/posttrainarena/blob/main/docs/native-dataset-openenv-smoke.md)
+- [Native-dataset OpenEnv smoke report](./docs/native-dataset-openenv-smoke.md)
 - [Starting-kit guide](./starting-kit/README.md)
 - [Team submission guide](./submissions/README.md)
 - [Security](./SECURITY.md) · [Support](./SUPPORT.md) · [Code of conduct](./CODE_OF_CONDUCT.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,16 +24,20 @@ Security-sensitive surfaces include:
 - provider and Hugging Face credentials
 - private held-out evaluation data
 - generated trajectories, checkpoints, and model artifacts
-- future protocol adapters, including any OpenEnv server/client boundary
+- protocol adapters, including the implemented OpenEnv server/client boundary
 
 Never commit secrets, raw provider responses containing secrets, checkpoints,
 private eval tasks, or unreviewed job dumps. Use environment variables or a
 secret manager, pin external revisions, and keep generated runs in ignored
 directories.
 
-The current repository has no OpenEnv server. Any future adapter must preserve
-sandbox isolation across resets, avoid exposing verifier secrets or private
-evaluation data through observations/state, and include an end-to-end security
-test before compatibility is claimed.
+The repository includes `posttrainarena-train openenv-serve`, which wraps
+BenchFlow-backed tasks behind the OpenEnv client/server protocol. Operators
+must keep private task snapshots and verifier credentials server-side, bind the
+raw service to loopback or a private network, and place any remote access behind
+encrypted authenticated ingress plus network allowlisting. The command has no
+built-in authentication and must never be exposed directly to the public
+internet. Preserve sandbox isolation across resets and run the lifecycle plus
+Docker-parity tests before changing this boundary.
 
 The competition is a proposal and does not currently provide a production SLA.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,13 +4,17 @@ Use the channel that matches the request:
 
 - **Environment authoring and task-contract questions:** open a GitHub issue
   with a minimal task-package example, or ask in the project Discord.
-- **Training-pipeline bugs:** open a GitHub issue with the recipe revision, task
-  IDs, command, sanitized logs, and whether the failure reproduces with
-  `--dry-run`.
+- **Training-pipeline bugs:** open a GitHub issue with the recipe revision,
+  redacted or public task IDs, command, sanitized logs, and whether the failure
+  reproduces with `--dry-run`. Never include sealed-eval IDs or private task
+  contents.
 - **OpenEnv integration:** first check
-  [`docs/architecture-status.md`](docs/architecture-status.md). Compatibility is
-  not currently implemented; proposals should include a real OpenEnv
-  client/server lifecycle and isolation test rather than only format conversion.
+  [`docs/architecture-status.md`](docs/architecture-status.md). The served
+  adapter, typed client, lifecycle tests, and Docker parity path are
+  implemented. Public bug reports may include the sanitized `openenv-serve`
+  command and environment backend, but must redact private task IDs, state
+  contents, credentials, and artifact paths. Report any possible private-data
+  exposure through the security channel below.
 - **Competition rules or private submission questions:** email
   `labs@benchflow.ai`.
 - **Security, leaked credentials, sandbox escapes, or private eval exposure:**

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # Documentation map
 
+<!-- markdownlint-disable MD013 MD060 -->
+
 | Document | Audience | Purpose |
 |---|---|---|
 | [`../README.md`](../README.md) | Everyone | Competition overview, repository map, and implementation status |
@@ -7,17 +9,26 @@
 | [`../CONTRIBUTING.md`](../CONTRIBUTING.md) | Contributors | Submission rules, environment authoring, reviews, and pipeline contributions |
 | [`training-pipeline.md`](training-pipeline.md) | Organizers and researchers | Canonical BenchFlow + TRL operator guide, configuration, execution, artifacts, and evidence limits |
 | [`hf-jobs.md`](hf-jobs.md) | Organizers and Hugging Face collaborators | Submission-to-recipe bridge, HF UV Jobs, artifact publication, multi-benchmark evaluation, and leaderboard hosting |
-| [`hf-jobs-validation.md`](hf-jobs-validation.md) | Reviewers and operators | H100 wrapper evidence, Hub outputs, live Space, and the current HF Jobs credit blocker |
-| [`qwen35-opencode-teacher-canary.md`](qwen35-opencode-teacher-canary.md) | Reviewers and operators | Real Qwen3.5-397B OpenCode rollout, trajectory, and TRL conversion evidence |
-| [`qwen35-data-agent-e2e-canary.md`](qwen35-data-agent-e2e-canary.md) | Reviewers and operators | Real Qwen3.5-9B LoRA SFT, OpenCode GRPO, synchronization, and held-out score evidence |
+| [`hf-jobs-validation.md`](hf-jobs-validation.md) | Reviewers and operators | Historical H100 wrapper evidence, Hub outputs, live Space, and the July 11 HF Jobs credit blocker |
+| [`opencode-grpo.md`](opencode-grpo.md) | Operators and trainer authors | Current OpenCode rollout, bridge, exact-token, synchronization, and GRPO update contract |
+| [`opencode-evaluation-canary.md`](opencode-evaluation-canary.md) | Reviewers and operators | Historical single-task OpenCode evaluator evidence |
+| [`opencode-grpo-smoke.md`](opencode-grpo-smoke.md) | Reviewers and operators | Historical Qwen3-4B OpenCode SFT-to-GRPO plumbing smoke |
+| [`native-dataset-openenv-smoke.md`](native-dataset-openenv-smoke.md) | Reviewers and operators | Historical native-dataset OpenEnv execution evidence |
+| [`qwen35-opencode-teacher-canary.md`](qwen35-opencode-teacher-canary.md) | Reviewers and operators | Historical single-task Qwen3.5-397B-A17B OpenCode rollout, trajectory, and TRL conversion evidence |
+| [`qwen35-data-agent-e2e-canary.md`](qwen35-data-agent-e2e-canary.md) | Reviewers and operators | Qwen3.5-9B LoRA SFT, OpenCode GRPO, synchronization, and exploratory same-domain score evidence |
 | [`../starting-kit/README.md`](../starting-kit/README.md) | Environment authors | Task package template and worked examples |
 | [`../submissions/README.md`](../submissions/README.md) | Teams | Team-entry layout and submission manifest |
 | [`../SECURITY.md`](../SECURITY.md) | Security reporters | Private vulnerability reporting and secret-handling expectations |
 | [`../SUPPORT.md`](../SUPPORT.md) | Users | Where to ask usage, competition, and incident questions |
+| [`../CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) | Contributors | Community participation and enforcement expectations |
 
-The final competition budget and sealed evaluation remain draft. The
-Qwen3.5-9B implementation under `pipelines/benchflow-task-posttrain/` defines
-executable behavior, while
+The final competition budget and sealed evaluation remain draft. The public
+reference recipe uses the pinned 2,238-task train and 366-task eval datasets;
+competition recipes replace those with a participant training corpus and the
+organizer's internal evaluation tasks. The Qwen3.5-9B implementation under
+`pipelines/benchflow-task-posttrain/` defines executable behavior, while
 [`architecture-status.md`](architecture-status.md) defines compatibility and
-roadmap status. OpenEnv and HF Jobs are implemented by the public pipeline;
-competition-scale recipes and private final evaluation remain draft.
+roadmap status. OpenEnv and HF Jobs are implemented by the public pipeline. An
+exploratory 16-train/14-eval same-domain run observed `8/14 → 11/14`; full
+public-reference execution, competition generalization, and private-final
+evidence remain pending.

--- a/docs/architecture-status.md
+++ b/docs/architecture-status.md
@@ -1,5 +1,7 @@
 # Architecture and implementation status
 
+<!-- markdownlint-disable MD013 MD060 -->
+
 This document separates the PostTrain Arena vision from what is implemented in
 the public repository today. It is the source of truth for compatibility and
 roadmap claims.
@@ -18,9 +20,10 @@ team task corpus
     -> lift over a fixed reference checkpoint
 ```
 
-The organizer implementation now targets Qwen3.5-9B with a private BenchFlow
-Signals evaluation suite. The competition rules and final compute budget remain
-draft until the Qwen3.5 recipe is validated at scale.
+The organizer implementation targets Qwen3.5-9B with a private BenchFlow
+Signals evaluation suite. The exploratory public 16-train/14-eval same-domain
+canary validates the recipe and model update path; the competition rules, final
+compute budget, and private-suite scale remain draft.
 
 ## Current public implementation
 
@@ -57,11 +60,14 @@ The final machine-readable contract is:
 runs/<run-name>/reports/score.json
 ```
 
-The full checked-in recipe covers all 2,238 public training tasks and all 366
-held-out public evaluation tasks. Historical Qwen3-4B smokes and the current
-Qwen3.5 Data Agent eight-train/three-eval canary validate the orchestration,
-but the latest held-out pass rate remained `1/3 -> 1/3`; model-quality lift and
-competition-scale readiness remain unproven.
+The full checked-in public reference recipe covers all 2,238 training tasks and
+all 366 held-out evaluation tasks at immutable pinned Hub revisions.
+Competition recipes keep the model and optimizer contract fixed while
+replacing the training dataset/task list with one participant corpus and the
+eval dataset/task list with the organizer's sealed internal tasks. The
+exploratory 16-train/14-eval public canary completed the corrected path and
+observed a same-domain pass-rate increase from `8/14` to `11/14`; the full
+public-reference run and private competition readiness remain unproven.
 
 ## Ownership boundaries
 
@@ -86,18 +92,18 @@ competition-scale readiness remain unproven.
 | TRL GRPO | Implemented | Qwen3.5 full recipe always runs one epoch over all training tasks; the custom OpenCode rollout function returns token IDs, sampled logprobs, action mask, and BenchFlow verifier reward; optimization is LoRA without quantization |
 | OpenCode teacher collection | Implemented | Provider-qualified Qwen3.5-397B-A17B teacher, required usage tracking, adaptive retries, and fail-closed one-training-ready-rollout-per-task coverage |
 | OpenCode evaluation | Implemented and live Qwen3.5 validated | Baseline, post-SFT, training gate, final, and multi-benchmark evaluation all use `bench eval run --agent opencode`; real SkillsBench and Qwen3.5 Data Agent canaries produced complete telemetry and healthy trajectories |
-| OpenCode GRPO | Corrected; live rerun pending | TRL custom rollout function invokes OpenCode/BenchFlow, consumes exact served prompt/completion IDs plus sampled logprobs, forwards verifier reward, and resynchronizes the vLLM endpoint; post-run audit found the older Qwen3.5 canary had `0/321` prompt-token-count matches, so it is not valid optimization evidence |
+| OpenCode GRPO | Implemented and live Qwen3.5 validated | TRL custom rollout function invokes OpenCode/BenchFlow, consumes exact served prompt/completion IDs plus sampled logprobs, forwards verifier reward, rejects zero-variance/no-update adapters, and resynchronizes the vLLM endpoint; the corrected run completed 128 rollouts and updated all 248 LoRA-B tensors |
 | Harbor | Not a dependency | No Harbor adapter or trajectory translation is used |
 | OpenEnv client/server lifecycle | Implemented | Pinned dependency, served adapter, typed client, real lifecycle tests, finalization, state, and session isolation |
 | OpenEnv/BenchFlow Docker parity | Manually validated | Checked-in security task produced identical output and reward `1.0` through both integrations; CI uses a no-spend fake BenchFlow boundary |
-| Native Data Agent pipeline | Orchestration live validated; corrected GRPO rerun pending | Eight training and three disjoint held-out native `task.md` packages completed the full stage sequence, but the historical GRPO prompt reconstruction was not token-aligned with serving |
+| Native Data Agent pipeline | Live canary validated | Sixteen training and 14 disjoint evaluation task IDs from the same source dataset completed strict teacher collection, LoRA SFT, 128 OpenCode GRPO rollouts, synchronization, and paired evaluation with an exploratory `8/14 -> 11/14` increase |
 | Submission-to-recipe bridge | Implemented | Environment entries become pinned Hub datasets and portable recipes |
-| HF Jobs execution | Canary handoff implemented; scheduler credit blocked | UV job bundle and historical H100 runner validated; the Docker-based Qwen3.5 full recipe currently targets a persistent native Linux GPU host |
+| HF Jobs execution | Canary handoff implemented; current allocation unverified | UV job bundle and historical H100 runner validated; July 11 scheduler requests were credit-blocked, and no paid scheduler launch was submitted during the July 15 documentation audit; the Docker-based Qwen3.5 full recipe currently targets a persistent native Linux GPU host |
 | Hub artifact publishing | Implemented | Run reports, checkpoint provenance, logs, and failures publish to Hub datasets/models |
 | Continuous leaderboard | Implemented | Atomic dataset records plus a deployable Gradio Space |
 | Multi-benchmark evaluation | Implemented | One base/final checkpoint pair is evaluated across pinned suites with macro delta |
-| Qwen3.5-9B competition recipe | Implemented; corrected live rerun pending | Immutable base/data revisions, declared Qwen3.5-397B teacher provenance, all-task teacher coverage, one-epoch LoRA SFT, one-epoch LoRA GRPO, exact served token IDs, and endpoint attestation are checked in; full-scale execution remains pending |
-| Demonstrated model-quality lift | Not yet | Reproduced smoke measured zero lift |
+| Qwen3.5-9B public reference recipe | Implemented and canary validated | Immutable base/data revisions, declared Qwen3.5-397B-A17B teacher provenance, all-task teacher coverage, one-epoch LoRA SFT, one-epoch LoRA GRPO, exact served token IDs, effective-update gates, and endpoint attestation are checked in; full 2,238/366 and private competition execution remain pending |
+| Observed canary uplift | Exploratory same-domain evidence only | Corrected run increased `8/14 -> 11/14` with zero regressions; the diagnostic slice was not a pre-registered generalization benchmark and the paired 95% interval includes zero |
 
 The OpenCode evaluation evidence is recorded in
 [`opencode-evaluation-canary.md`](opencode-evaluation-canary.md).

--- a/docs/hf-jobs-validation.md
+++ b/docs/hf-jobs-validation.md
@@ -3,8 +3,9 @@
 ## Verdict
 
 The PostTrain Arena Hugging Face handoff is implemented and its exact UV runner
-has completed the full pipeline on an H100. Allocation through the HF Jobs
-scheduler is currently blocked by account credits, not code.
+completed the historical pipeline on an H100. July 11 allocation attempts
+through the HF Jobs scheduler were blocked by account credits, not code;
+current paid-launch availability was not re-tested during the July 15 audit.
 
 This July 11 evidence predates the OpenCode evaluation migration. It validates
 the HF bundle, trainer, publishing, and earlier TRL evaluation path. The current
@@ -70,8 +71,12 @@ Real `hf jobs uv run` requests reached the official API under the `benchflow`,
 Required` with the same reason: insufficient prepaid Jobs credits.
 
 The uploaded script and bundle were therefore executed on a dedicated H100
-outside the HF scheduler. No code or secret-boundary change is required to
-retry after HF grants or billing are enabled.
+outside the HF scheduler. Authenticated job listing succeeded on July 15 and
+showed no active jobs, but that read-only check does not prove credits are now
+available. The next paid scheduler retry must validate the current
+Qwen3.5/OpenCode path, including authenticated model ingress, Docker
+availability, and separate trainer/vLLM GPU placement; those constraints may
+require topology or secret-boundary changes.
 
 ## Cleanup
 

--- a/docs/hf-jobs.md
+++ b/docs/hf-jobs.md
@@ -47,6 +47,12 @@ lists, immutable recipe, and a machine-readable preparation manifest. Uploaded
 submission datasets are private by default; use `--public` only during the
 explicit post-competition release.
 
+The public command above inherits the 366-task public eval list from the base
+config. For a competition run, organizers use the same model/SFT/GRPO settings
+in a private base config whose `eval_dataset` and task list point at the sealed
+internal suite; `prepare-submission` replaces only the training dataset/list
+with the participant corpus.
+
 ## 2. Test the HF path without GPU spend
 
 Inspect the portable bundle without creating any remote resource:
@@ -168,21 +174,29 @@ posttrainarena-train openenv-serve \
   --include-task 0000_369_369503_qa_1 \
   --environment daytona \
   --jobs-dir .local/openenv-jobs \
-  --host 0.0.0.0 \
+  --host 127.0.0.1 \
   --port 8000
 ```
 
-The server resolves client task IDs to its own pinned task paths. Competition
-HF Jobs normally use co-located mode so all artifacts remain directly
-publishable by the job runner.
+The server resolves client task IDs to its own pinned task paths. Optional
+OpenEnv compatibility jobs can use co-located mode so artifacts remain directly
+publishable by the job runner; the current Qwen3.5/OpenCode training job does
+not use OpenEnv. The command has no built-in authentication; never expose its
+raw port publicly. Remote access requires encrypted, authenticated ingress plus
+network allowlisting.
 
 ## Validation and current HF blocker
 
-The exact UV runner completed the full submission-to-training-to-leaderboard
-flow on an H100, including Data Agent and SkillsBench evaluation. See
+The exact UV runner completed the historical pre-OpenCode
+submission-to-training-to-leaderboard flow on an H100, including Data Agent and
+SkillsBench evaluation. The current Qwen3.5/OpenCode topology still requires a
+paid scheduler rerun. See
 [`hf-jobs-validation.md`](hf-jobs-validation.md).
 
-HF Jobs allocation itself currently returns HTTP 402 for all available
-namespaces because prepaid Jobs credits are unavailable. After HF enables the
-grant or billing balance, rerun the documented `hf-job-submit` command without
-any code change.
+The July 11 scheduler attempts returned HTTP 402 for all tested namespaces
+because prepaid Jobs credits were unavailable. During the July 15 documentation
+audit, authenticated `hf jobs ps --namespace benchflow` succeeded and returned
+no jobs; no paid launch was submitted, so current credit availability is
+unverified. The native two-H100 run validates the current OpenCode/Qwen3.5
+pipeline independently, but does not validate managed HF Jobs support for its
+Docker, ingress, and two-physical-GPU topology.

--- a/docs/native-dataset-openenv-smoke.md
+++ b/docs/native-dataset-openenv-smoke.md
@@ -46,7 +46,8 @@ not model-quality lift.
 - W&B run:
   `benchflow-ai/posttrainarena-native-dataset-e2e/cf7o84cb`
 
-The checkpoint PRs remain open and unmerged.
+At the time of this historical smoke, the checkpoint discussions were still
+open and unmerged; they are not part of the current Qwen3.5 organizer recipe.
 
 ## Cleanup
 

--- a/docs/opencode-evaluation-canary.md
+++ b/docs/opencode-evaluation-canary.md
@@ -33,7 +33,6 @@ were supplied only through process environment variables.
 
 This proves the OpenCode evaluation command, endpoint environment mapping,
 Daytona execution, verifier scoring, and fail-closed artifact-health checks.
-It does not prove evaluation of a newly trained checkpoint; that requires the
-student endpoint to load the checkpoint before evaluation. The current pipeline
-implements that synchronization through TRL's vLLM weight-transfer path; a live
-GPU training smoke remains separate.
+The later Qwen3.5 Data Agent run additionally validates synchronized SFT and
+GRPO checkpoints plus final held-out evaluation; see
+[`qwen35-data-agent-e2e-canary.md`](qwen35-data-agent-e2e-canary.md).

--- a/docs/opencode-grpo-smoke.md
+++ b/docs/opencode-grpo-smoke.md
@@ -1,5 +1,7 @@
 # OpenCode SFT-to-GRPO smoke
 
+<!-- markdownlint-disable MD013 -->
+
 On July 13, 2026, the Qwen3-4B reference pipeline completed a real
 OpenCode-only teacher, evaluation, and GRPO run on SkillsBench tasks with
 Daytona sandboxes.

--- a/docs/opencode-grpo.md
+++ b/docs/opencode-grpo.md
@@ -128,8 +128,9 @@ independently retokenizing the OpenAI request.
 Model-generated tokens receive action mask `1`; tool results, environment
 feedback, and the next assistant-generation prefix receive mask `0`. Provider
 token bytes are retokenized only as a fallback and must match both the exact
-served completion IDs and provider token count. BenchFlow call-purpose metadata excludes OpenCode helper
-calls, and explicit failed provider attempts are ignored when OpenCode later
+served completion IDs and provider token count. BenchFlow call-purpose metadata
+excludes OpenCode helper calls, and explicit failed provider attempts are
+ignored when OpenCode later
 records a successful retry. If structured tool messages canonicalize a suffix
 of prior sampled text, the parser rolls back only that suffix and masks the
 canonical replacement as environment context. If OpenCode refreshes dynamic
@@ -173,6 +174,11 @@ policy attestation, vLLM wiring, and final synchronization are covered by
 no-spend tests. A post-run audit of the July 14 Qwen3.5 canary found that the
 older implementation independently retokenized prompts: `0/321` sampled agent
 exchanges matched the exact prompt-token count reported by the serving
-endpoint. That historical run remains orchestration evidence, not valid GRPO
-optimization evidence. The corrected exact-ID path requires a clean live
-rerun.
+endpoint. That historical run remains orchestration evidence only.
+
+The corrected July 15 run used exact served IDs for 128 OpenCode GRPO rollouts,
+completed 16/16 reward groups, observed four mixed groups, logged 30 nonzero
+gradient steps, updated all 248 LoRA-B tensors with finite values, and observed
+a same-domain pass-rate increase from `8/14` to `11/14` with zero regressions.
+This validates the current rollout contract on an exploratory public canary; it
+does not establish generalization or replace private competition evaluation.

--- a/docs/qwen35-data-agent-e2e-canary.md
+++ b/docs/qwen35-data-agent-e2e-canary.md
@@ -1,14 +1,66 @@
 # Qwen3.5 Data Agent SFT-to-GRPO validation
 
-This document retains the historical July 14 soccer canary and the clean
-July 15, 2026 lift run that supersedes its GRPO claim boundary.
+This document retains the historical July 14 soccer canary and the exploratory
+July 15, 2026 same-domain run that supersedes its GRPO claim boundary.
 
 ## Clean exact-ID lift run
 
+This is an exploratory same-domain canary, not a generalization benchmark.
+
 The run `qwen35-9b-redwine-full-v3-main-69e37ed7` used 16 red-wine training
-tasks and 14 disjoint held-out tasks on two H100 80 GB GPUs. OpenCode was the
-agent harness for teacher collection, baseline/SFT/final evaluation, and every
-GRPO rollout.
+task IDs and 14 disjoint evaluation task IDs on two H100 80 GB GPUs. All 30
+tasks use the same `winequality-red.csv` source domain. The slice was selected
+as a pipeline diagnostic rather than a pre-registered generalization
+benchmark, so the result is evidence about the update path and same-domain
+behavior only. OpenCode was the agent harness for teacher collection,
+baseline/SFT/final evaluation, and every GRPO rollout.
+
+### Pinned data and exact task lists
+
+- Train dataset:
+  `benchflow/data_agent_rl_environment_train@34ff63c91731df6b3670bfcd7e3d44e6790ddc48`
+- Eval dataset:
+  `benchflow/data_agent_rl_environment_eval@0ea976c79e3248c85737c4f7363484e4d47ce287`
+
+#### 16 training task IDs
+
+```text
+0013_408_13408860_qa_5
+0017_291_17291057_qa_5
+0023_772_23772737_qa_1
+0033_273_33273125_qa_1
+0039_655_39655291_qa_2
+0039_873_39873778_qa_5
+0040_785_40785152_qa_2
+0040_785_40785152_qa_5
+0043_419_43419580_qa_2
+0050_854_50854581_qa_3
+0053_603_53603838_qa_2
+0053_603_53603838_qa_3
+0054_269_54269608_qa_3
+0057_632_57632820_qa_1
+0057_712_57712524_qa_4
+0067_118_67118977_qa_5
+```
+
+#### 14 held-out evaluation task IDs
+
+```text
+0019_309_19309067_qa_5
+0043_774_43774308_qa_2
+0047_164_47164651_qa_1
+0054_900_54900562_qa_1
+0060_546_60546361_qa_2
+0069_624_69624642_qa_5
+0077_266_77266642_qa_2
+0084_727_84727795_qa_4
+0086_400_86400737_qa_5
+0095_395_95395894_qa_2
+0119_351_119351337_qa_3
+0124_418_124418283_qa_2
+0055_115_55115812_qa_1
+0116_195_116195791_qa_2
+```
 
 The path completed with:
 
@@ -31,14 +83,17 @@ The path completed with:
 The final pass set was a strict superset of the baseline pass set: tasks
 `0047_164_47164651_qa_1`, `0060_546_60546361_qa_2`, and
 `0095_395_95395894_qa_2` improved, with zero regressions. The paired bootstrap
-95% interval for pass-rate lift was `[0.0%, 42.9%]`; this is real single-run
-evidence on the 14-task canary, not a competition-scale statistical claim.
+95% interval for pass-rate lift was `[0.0%, 42.9%]`; this is an observed
+single-run increase on a same-domain diagnostic slice, not evidence of broad
+generalization or a competition-scale statistical claim.
 
 PostTrainArena commit
-`cf824b214e5ae08d6fc21becbcba7aae55e5109e` produced the run. The runtime used
-BenchFlow commit `6d6d2ee0965bdc7fe1e38555d1f7c4c21ee8a840`, whose OpenCode
-`1.17.20` pin was merged from BenchFlow PR #931 as
-`2a97db55947d6742b765ad34ddd91d74c20d625f`.
+`cf824b214e5ae08d6fc21becbcba7aae55e5109e` produced the run. Its embedded
+`plan.json` and `score.json` retained that commit's older static BenchFlow
+metadata, `cbc295464e62aa39f84e0daa675aa939c0e72f00`. Archived agent install logs
+record `opencode-ai@1.17.20`, the only behavior change in direct child commit
+`6d6d2ee0965bdc7fe1e38555d1f7c4c21ee8a840`; that commit later merged from
+BenchFlow PR #931 as `2a97db55947d6742b765ad34ddd91d74c20d625f`.
 
 ## Historical soccer canary
 
@@ -67,11 +122,11 @@ every selected training task.
 
 The run was resumed while this canary threshold was being debugged: its first
 teacher manifest still declared strict `8/8` coverage, while the effective
-continued recipe accepted the four verified trajectories. The same branch now
+continued recipe accepted the four verified trajectories. Current resume code
 validates the exact task IDs, teacher provenance, threshold, and coverage mode
 before reusing teacher state, so this kind of recipe drift fails closed. A
-clean run from the final checked-in recipe remains part of the next
-matched-domain quality experiment.
+clean rerun of that exact soccer slice was not performed; the red-wine run
+above supersedes it as validation of the current GRPO contract.
 
 ## Completed path
 
@@ -150,7 +205,9 @@ a recipe change during resume and its old rollout parser reconstructed prompt
 IDs incorrectly, so its `1/3 -> 1/3` result is not valid GRPO-learning
 evidence.
 
-The clean red-wine run above closes that gap: exact served prompt IDs,
+The exploratory red-wine run above closes that mechanics gap: exact served
+prompt IDs,
 provider-sampled logprobs, OpenCode-only rollouts, finite nonzero LoRA updates,
-and healthy held-out evaluation jointly establish a valid `8/14 -> 11/14`
-post-training lift on the canary slice.
+and healthy evaluation jointly establish a real `8/14 -> 11/14` same-domain
+pass-rate increase on the canary slice. They do not establish broad
+model-quality or competition generalization.

--- a/docs/qwen35-opencode-teacher-canary.md
+++ b/docs/qwen35-opencode-teacher-canary.md
@@ -48,7 +48,10 @@ With that fix applied, the real rollout produced and validated:
 
 ## Claim boundary
 
-This proves the Qwen3.5 teacher, OpenCode tool loop, BenchFlow telemetry, raw
-trajectory capture, and Qwen3.5-aware TRL conversion on a real task. It does
-not prove the 2,238-task Data Agent run, Qwen3.5-9B SFT/GRPO optimization, or
-held-out model lift. Those require the native Linux GPU canary.
+This historical canary proves the Qwen3.5 teacher, OpenCode tool loop,
+BenchFlow telemetry, raw trajectory capture, and Qwen3.5-aware TRL conversion
+on one real task. The later native Linux GPU canary validates Qwen3.5-9B
+SFT/GRPO and exploratory same-domain uplift on a 16-train/14-eval slice.
+Neither run is the full 2,238-task public-reference execution or a
+participant-corpus/private-eval competition run. See
+[`qwen35-data-agent-e2e-canary.md`](qwen35-data-agent-e2e-canary.md).

--- a/docs/training-pipeline.md
+++ b/docs/training-pipeline.md
@@ -1,5 +1,7 @@
 # BenchFlow task-list post-training pipeline
 
+<!-- markdownlint-disable MD013 MD060 -->
+
 This is the canonical operator guide for the public organizer-side training
 implementation under
 [`pipelines/benchflow-task-posttrain/`](../pipelines/benchflow-task-posttrain).
@@ -28,17 +30,24 @@ training task list + held-out eval task list + pinned TOML recipe
 ```
 
 BenchFlow owns task snapshots, Daytona or Docker sandboxes, verifiers, reward
-extraction, rollout artifacts, and paired evaluation. OpenCode owns the teacher
-evaluation, and GRPO agent loops. TRL owns SFT and GRPO optimization plus vLLM
-weight synchronization. The pipeline is Harbor-free and does not translate
-Harbor trajectories.
+extraction, rollout artifacts, and paired evaluation. OpenCode owns teacher
+collection, evaluation, and GRPO agent loops. TRL owns SFT and GRPO
+optimization plus vLLM weight synchronization. The pipeline is Harbor-free and
+does not translate Harbor trajectories.
 
-The organizer recipe pins the public BenchFlow-native conversions:
+The public reference recipe pins the BenchFlow-native datasets:
 
 - `benchflow/data_agent_rl_environment_train` (`2,238` training tasks)
 - `benchflow/data_agent_rl_environment_eval` (`366` held-out tasks)
 
-Both repositories use `task.md`, `environment/`, and `verifier/` directly.
+Both repositories use `task.md`, `environment/`, and `verifier/` directly. On
+July 15, 2026, their `main` revisions matched the checked-in immutable pins:
+train `34ff63c91731df6b3670bfcd7e3d44e6790ddc48` with 2,238 unique tasks and
+eval `0ea976c79e3248c85737c4f7363484e4d47ce287` with 366 unique tasks; neither
+contained legacy `task.toml` files. For competition runs,
+`prepare-submission` replaces the training repository/list with the participant
+corpus; organizers start from a private base recipe whose eval repository/list
+points at the sealed internal suite.
 
 A real one-train/one-held-out OpenEnv run completed the full snapshot, teacher,
 SFT, forced-GRPO, final-eval, and publication path on these revisions. See
@@ -137,8 +146,10 @@ The minimal 1x1 validation recipe is
 [`configs/qwen3.5-9b-data-agent-canary.toml`](../pipelines/benchflow-task-posttrain/configs/qwen3.5-9b-data-agent-canary.toml).
 The domain-matched eight-train/three-eval recipe is
 [`configs/qwen3.5-9b-data-agent-soccer-canary.toml`](../pipelines/benchflow-task-posttrain/configs/qwen3.5-9b-data-agent-soccer-canary.toml).
-The current teacher/provider and TRL conversion evidence is recorded in
-[`qwen35-opencode-teacher-canary.md`](qwen35-opencode-teacher-canary.md).
+Historical single-task teacher/provider and TRL conversion evidence is recorded
+in [`qwen35-opencode-teacher-canary.md`](qwen35-opencode-teacher-canary.md).
+The current end-to-end update-path evidence is recorded in
+[`qwen35-data-agent-e2e-canary.md`](qwen35-data-agent-e2e-canary.md).
 
 ## No-spend validation
 
@@ -172,7 +183,7 @@ Dry-run records the full possible path, including conditional GRPO. Therefore
 | `[train_dataset]` | HF task repository, revision, path, and training task-list file |
 | `[eval_dataset]` | Separate HF repository/revision and held-out task-list file |
 | `[runtime]` | Daytona/Docker sandbox, GRPO completion-token budget, and generation count |
-| `[harness]` | Required OpenCode contract, skill mode, telemetry, concurrency, and setup/idle/wall-clock timeouts for teacher collection and evaluation |
+| `[harness]` | Required OpenCode contract, skill mode, telemetry, concurrency, and setup/idle/wall-clock timeouts for teacher collection, evaluation, and GRPO rollouts |
 | `[evaluation]` | Environment-variable names for the served base/student model aliases and OpenAI-compatible endpoint credentials |
 | `[teacher]` | Provider-qualified teacher route, declared source identity/revision, adaptive attempts, reward threshold, post-run token/tool acceptance ceilings, and all-task coverage policy |
 | `[sft]` | Enable flag, epoch or smoke-step schedule, optimizer settings, tokenizer-aware message-window length, and LoRA dimensions |
@@ -290,7 +301,8 @@ The GRPO rollout format and endpoint topology are documented in
 [`opencode-grpo.md`](opencode-grpo.md).
 The real OpenCode-only SFT-to-GRPO validation is documented in
 [`opencode-grpo-smoke.md`](opencode-grpo-smoke.md).
-The Qwen3.5 Data Agent eight-train/three-eval run is documented in
+The exploratory same-domain Qwen3.5 Data Agent 16-train/14-eval run and the
+historical eight-train/three-eval soccer canary are documented in
 [`qwen35-data-agent-e2e-canary.md`](qwen35-data-agent-e2e-canary.md).
 
 ## SFT, RL-only, and reward gating
@@ -361,18 +373,17 @@ The checked-in production GRPO recipe trains one same-prompt group at a time:
 eight generations, generation batch eight, and no gradient accumulation. The
 trainer still recomputes policy logprobs with a per-device microbatch of one to
 fit long OpenCode trajectories on the 80 GB trainer GPU. The bootstrap also
-enables PyTorch expandable CUDA
-segments to reduce allocator fragmentation, and the GRPO trainer clears cached
-CUDA allocations between steps.
+enables PyTorch expandable CUDA segments to reduce allocator fragmentation, and
+the GRPO trainer clears cached CUDA allocations between steps.
 
 Use W&B for spendful runs to track training loss and GPU utilization. Terminate
 GPU hosts after artifacts and checkpoints are backed up.
 
 ## Historical validation evidence and limits
 
-The clean Qwen3.5-9B run
-`qwen35-9b-redwine-full-v3-main-69e37ed7` is the current end-to-end quality
-proof:
+The exploratory Qwen3.5-9B run
+`qwen35-9b-redwine-full-v3-main-69e37ed7` is the current end-to-end
+update-path proof:
 
 - 16/16 verified Qwen3.5-397B-A17B teacher tasks
 - 63 tool-calling SFT rows and one LoRA SFT epoch
@@ -381,9 +392,10 @@ proof:
 - all 248 LoRA-B tensors updated with finite values
 - held-out pass rate `8/14 -> 11/14`, with zero task regressions
 
-This is a valid paired lift on a small canary slice. The bootstrap 95% interval
-includes zero, so competition-scale claims still require the full private eval
-set and repeated or larger-sample evidence.
+This is an observed paired pass-rate increase on disjoint task IDs from the
+same source dataset. The slice was diagnostic rather than pre-registered and
+the bootstrap 95% interval includes zero, so generalization claims still
+require the sealed private eval set and repeated or larger-sample evidence.
 
 The retained Qwen3-4B recipe mirrors a completed H100 smoke with:
 
@@ -396,10 +408,10 @@ The retained Qwen3-4B recipe mirrors a completed H100 smoke with:
 - GRPO correctly skipped
 - final paired delta `0.0`
 
-This validates task loading, sandbox/tool execution, verification, SFT data
-conversion, training, reward gating, reporting, and the skip path. It does not
-demonstrate model-quality lift. Quality claims require larger training and
-held-out sets with non-zero reward signal.
+This historical smoke validates task loading, sandbox/tool execution,
+verification, SFT data conversion, training, reward gating, reporting, and the
+skip path. It does not add update evidence beyond the exploratory Qwen3.5
+canary above.
 
 ## Development checks
 

--- a/pipelines/benchflow-task-posttrain/README.md
+++ b/pipelines/benchflow-task-posttrain/README.md
@@ -31,10 +31,16 @@ recipes pin the public BenchFlow-native `task.md` datasets
 `benchflow/data_agent_rl_environment_eval`. The pipeline does not depend on
 Harbor or translate Harbor trajectories.
 
+The public full recipe uses all 2,238 training and 366 evaluation tasks. For
+competition entries, `prepare-submission` replaces the training repository and
+task list with the participant corpus; organizers supply a private base recipe
+whose eval repository and task list point at the sealed internal suite.
+
 After snapshotting, the pipeline hashes canonical package content and rejects
 an exact train/eval package duplicate even when it appears under a different
 task ID. This complements, but does not replace, the organizer's semantic
 leakage audit for private evaluation.
+
 ## Repository Layout
 
 ```text
@@ -199,12 +205,16 @@ official default, and requires at least one group with nonzero verifier-reward
 variance before it publishes a GRPO adapter. Two-generation settings remain in
 the canary and smoke recipes for cost control.
 
-Do not use held-out eval tasks to tune this gate. Production recipes should use
-separate training, gate/development, and final evaluation lists.
+Do not use held-out eval tasks to tune this gate. The current contract derives
+the gate from training tasks and uses the eval list for baseline, post-SFT, and
+final paired scoring. A separate development-list surface would require a
+future recipe/schema change.
 
 ## Qwen3.5 Data Agent Lift Result
 
-The clean July 15, 2026 Docker + OpenCode run on two H100 80 GB GPUs completed:
+This result is exploratory same-domain evidence. The July 15, 2026 Docker +
+OpenCode diagnostic run on two H100 80 GB GPUs used disjoint task IDs from the
+same red-wine source dataset and completed:
 
 - strict `16/16` verifier-approved Qwen3.5-397B-A17B teacher coverage
 - 63 validated tool-calling TRL SFT rows and one bf16 LoRA SFT epoch
@@ -214,6 +224,8 @@ The clean July 15, 2026 Docker + OpenCode run on two H100 80 GB GPUs completed:
 - held-out baseline/SFT/final pass rates `8/14`, `8/14`, and `11/14`
 - paired lift `+3/14` (`+21.4` percentage points), with zero regressions
 
+This validates real policy updates and records exploratory same-domain uplift;
+it is not a broad generalization claim.
 The earlier July 14 soccer canary remains historical orchestration evidence
 because it predated exact served-prompt-ID reconstruction.
 See
@@ -245,7 +257,8 @@ Before opening a PR:
 ```bash
 python3 -m pytest pipelines/benchflow-task-posttrain/tests -q
 python3 -m py_compile \
-  pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/*.py \
+  pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/*.py
+python3 -m py_compile \
   pipelines/benchflow-task-posttrain/src/posttrainarena/benchflow_pipeline/openenv/*.py
 ```
 

--- a/starting-kit/README.md
+++ b/starting-kit/README.md
@@ -1,12 +1,15 @@
 # PostTrain Arena — starting kit
 
+<!-- markdownlint-disable MD060 -->
+
 This directory defines the participant-facing **PostTrain task package** format.
 It is intentionally runnable with Python and Docker and does not require
 BenchFlow, TRL, or OpenEnv for authoring checks.
 
 Organizer training later consumes selected task packages through the public
-BenchFlow + TRL pipeline. The repository does **not** currently expose these
-packages as OpenEnv client/server environments. See
+BenchFlow + TRL pipeline. Authors do not implement OpenEnv in their packages;
+the organizer can expose snapshotted BenchFlow tasks through the separate
+`openenv-serve` compatibility service. See
 [`docs/architecture-status.md`](../docs/architecture-status.md) for the exact
 boundary.
 

--- a/submissions/README.md
+++ b/submissions/README.md
@@ -1,5 +1,7 @@
 # Team submissions
 
+<!-- markdownlint-disable MD013 MD060 -->
+
 Submissions use the PostTrain Arena task-package and team-manifest contract.
 They are validated locally with the self-contained scripts in this repository;
 organizer training uses BenchFlow + TRL after intake. OpenEnv compatibility is
@@ -24,7 +26,7 @@ allow lowering the environments minimum if participation is low.
 
 ## Layout
 
-```
+```text
 submissions/<team-entry>/
   submission.yaml          # flat key: value
   envs/<env-name>/...      # track: environments
@@ -67,11 +69,17 @@ training recipe:
 ```bash
 posttrainarena-train prepare-submission \
   --entry submissions/<team-entry> \
-  --base-config pipelines/benchflow-task-posttrain/configs/qwen3-4b-data-agent-forced-grpo-smoke.toml \
+  --base-config pipelines/benchflow-task-posttrain/configs/qwen3.5-9b-data-agent-full.toml \
   --out .local/prepared/<team-entry> \
   --dataset-repo <namespace>/posttrainarena-<team-entry> \
   --upload
 ```
+
+This public example inherits the pinned 366-task public eval list. During the
+competition, organizers use a private base config with the same
+Qwen3.5-9B/OpenCode/one-epoch LoRA recipe and the sealed internal eval
+dataset/task list. Preparation replaces the training dataset/list with the
+participant corpus and sets strict teacher coverage to that corpus size.
 
 This managed SFT/GRPO bridge supports `track: environments`. Skill-track
 evaluation remains a separate frozen-agent workflow.


### PR DESCRIPTION
## Summary

- Audit every project-facing document and update the 18 files that contain pipeline, dataset, compatibility, security, or evidence claims.
- Make the executable contract consistent everywhere: Qwen3.5-9B student, Qwen3.5-397B-A17B teacher, OpenCode for teacher/evaluation/GRPO rollouts, one-epoch bf16 LoRA SFT, and one-epoch TRL LoRA GRPO.
- Pin the public examples to the current 2,238-task train and 366-task eval repositories, while separating those public references from participant-corpus training and the sealed competition eval set.
- Reclassify older Qwen3-4B, OpenEnv, soccer, and HF Jobs runs as historical evidence and scope the 16x14 result as exploratory same-domain uplift rather than competition generalization.
- Document the canary provenance boundary, OpenEnv exposure requirements, HF Jobs topology gap, and private task-ID redaction rules.

This is the smallest appropriate change because executable code and configs already implement the target pipeline; the remaining drift was in repository documentation.

## Validation

- [x] Existing task checks pass when relevant
- [x] Pipeline tests and documented CLI checks pass when relevant
- [x] No credentials, private eval content, checkpoints, or raw provider dumps are included
- [x] Dataset, model, and external dependency revisions are pinned when relevant
- [x] Public docs and evidence boundaries are updated when behavior or claims change
- [x] Compatibility changes update `docs/architecture-status.md` and retain existing contract coverage

Detailed checks:

- 238 pipeline tests passed
- Ruff and Python compilation passed for the pipeline package
- Starting-kit structural checks and submission checks passed
- Seven checked-in recipes validated; the full plan resolved to 2,238 train tasks, 366 eval tasks, Qwen3.5-9B, the Qwen3.5-397B-A17B teacher, and one epoch each for SFT and GRPO
- Qwen3.5 HF Job bundle dry-run passed
- Markdownlint passed on all 18 changed docs
- Modified-doc external and relative link checks passed
- Live Hugging Face verification matched all four pinned model/dataset SHAs; datasets contained 2,238/366 `task.md` packages and zero `task.toml` files
- Diff whitespace and credential-pattern scans passed

## Spend and external systems

No spendful validation. This PR uses the already-preserved public canary evidence and no GPU, provider, Daytona, or paid HF Job was launched. A paid HF Jobs run for the current Docker/OpenCode/two-GPU topology remains an explicit manual validation item.
